### PR TITLE
Use lodash size function

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -322,7 +322,7 @@ function define(nockDefs) {
     } else {
       nock = startScope(nscope, options);
       //  If request headers were specified filter by them.
-      if (reqheaders !== {}) {
+      if (_.size(reqheaders) > 0) {
         for (var k in reqheaders) {
           nock.matchHeader(k, reqheaders[k]);
         }


### PR DESCRIPTION
You cannot effectively compare anything to an empty object declaration. {} === {} will always equal false. This is to address the attended purpose by the comment provided. 

Found this while I was on my hunt down for why nock.define() fails when reqheader['content-type'] is provided on post routes.