### PR TITLE
Do not automatically consume responses, respect original consumer.

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -296,89 +296,23 @@ function record(rec_options) {
         return setEncoding.apply(this, arguments);
       };
 
-      //  Give the actual client a chance to setup its listeners.
-      //  We will use the listener information to figure out
-      //  how we need to feed the intercepted data back to the client.
-      if (callback) {
-        callback(res, options, callback);
-      }
-
-      //  Handle clients that listen to 'readable' by intercepting them
-      //  and feeding them the data manually.
-      var readableListeners = res.listeners('readable');
-      if (!_.isEmpty(readableListeners)) {
-
-        debug('handle readable listeners');
-
-        //  We will replace the client's listeners with our own and manually
-        //  invoke them.
-        _.each(readableListeners, function(listener) {
-          res.removeListener('readable', listener);
-        });
-
-        //  Repleace the actual Stream.Readable prototype 'read' function
-        //  so that we can control what the client listener will be reading.
-        var prototypeRead = Stream.Readable.prototype.read;
-        var currentReadIndex = 0;
-        res.read = function() {
-
-          debug(thisRecordingId, 'client reading data on', proto, dataChunks.length);
-
-          //  Feed the data to the client through from our collected data chunks.
-          if (currentReadIndex < dataChunks.length) {
-            debug('chunk', chunk, 'read');
-            var chunk = dataChunks[currentReadIndex];
-            ++currentReadIndex;
-            return chunk;
-          } else {
-            debug('no more chunks to read');
-            return null;
-          }
-
-        };
-
-        //  Put our own listener instead of the removed client listener.
-        var onReadable = function(data) {
-          debug(thisRecordingId, 'new readable data on', proto);
-          var chunk;
-          //  Use the prototypeRead function to actually read the data.
-          while (null !== (chunk = prototypeRead.call(res))) {
-            debug('read', chunk);
-            dataChunks.push(chunk);
-          }
-          //  Manually invoke the user listeners emulating 'readable' event.
-          _.each(readableListeners, function(listener) {
-            listener();
-          });
-        };
-
-        res.on('readable', onReadable);
-
-      } else {
-
-        //  In all other cases we (for now at least) fall back on intercepting
-        //  'data' events.
-        debug('fall back on our original implementation');
-
-        //  Since we gave client the chance to setup its listeners
-        //  before us, we need to remove them and setup our own.
-        var dataListeners = res.listeners('data');
-        _.each(dataListeners, function(listener) {
-          res.removeListener('data', listener);
-        });
-
-        var onData = function(data) {
-          debug(thisRecordingId, 'new data chunk on', proto);
+      // Replace res.push with our own implementation that stores chunks
+      var origResPush = res.push;
+      res.push = function(data) {
+        if (data) {
           if (encoding) {
             data = new Buffer(data, encoding);
           }
           dataChunks.push(data);
-          //  Manually invoke the user listeners emulating 'data' event.
-          _.each(dataListeners, function(listener) {
-            listener(data);
-          });
-        };
-        res.on('data', onData);
+        }
+
+        return origResPush.call(res, data);
+      }
+
+      if (callback) {
+        callback(res, options, callback);
+      } else {
+        res.resume();
       }
 
       debug('finished setting up intercepting');


### PR DESCRIPTION
Fixes #486 

After investigation, the issue is that the `recorder` assumes that all listeners are attached after http.request's `callback` is called which might not be the case. That's exactly what was happening with me because since [got](https://github.com/sindresorhus/got) is using promises, the `data` event was only attached in the next event loop.

Test case & fix added, I haven't committed the browserify bundle. I've tried to follow the coding style, let me know if something needs to be changed.