### PR TITLE
Fix nock.emitter.on('no match') undefined argument

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -383,7 +383,7 @@ function activate() {
       }
       return req;
     } else {
-      globalEmitter.emit('no match', req);
+      globalEmitter.emit('no match', options);
       if (isOff() || isEnabledForNetConnect(options)) {
         return overriddenRequest(options, callback);
       } else {

--- a/tests/test_events.js
+++ b/tests/test_events.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var nock    = require('../.');
-var http    = require('http');
-var test    = require('tap').test;
+var nock = require('../.');
+var http = require('http');
+var test = require('tap').test;
 
 test('emits request and replied events', function(t) {
   var scope = nock('http://eventland')
@@ -38,13 +38,26 @@ test('emits no match when no match and mocked', function(t) {
     .reply('howdy');
 
 
-  nock.emitter.on('no match', function(req) {
+  var assertion = function(req) {
     t.equal(req.path, '/definitelymaybe');
+    nock.emitter.removeAllListeners('no match');
     t.end();
-  });
+  }
+  var result = nock.emitter.on('no match', assertion);
 
   http.get('http://itmayormaynotexistidontknowreally/definitelymaybe')
     .once('error', ignore);
+});
+
+test('emits no match when netConnect is disabled', function(t) {
+  nock.disableNetConnect();
+  nock.emitter.on('no match', function(req) {
+    t.equal(req.hostname, 'jsonip.com')
+    nock.emitter.removeAllListeners('no match');
+    nock.enableNetConnect();
+    t.end();
+  });
+  http.get('http://jsonip.com').once('error', ignore);
 });
 
 function ignore() {}


### PR DESCRIPTION
Previously if you disabled net connect via `nock.disableNetConnect`,
`nock.emitter.on('no match')` would return undefined for its first argument,
since `req` is never initialized. Replaces `req` with `options`, which is
present and set to a Url instance.

Fixes the global nock.emitter.on event listener to remove all event listeners
at the end of each test, otherwise an event listener registered in one test
might bleed over into the next.

(This might not be the right fix, I'm happy to change as necessary).