### PR TITLE
properly remove interceptor with regex domain from the list after used

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -110,31 +110,16 @@ function add(key, interceptor, scope, scopeOptions, host) {
 }
 
 function remove(interceptor) {
-  if (interceptor.__nock_scope.shouldPersist()) {
+  if (interceptor.__nock_scope.shouldPersist() || --interceptor.counter > 0) {
     return;
   }
 
-  interceptor.counter -= 1;
-  if (interceptor.counter > 0) {
-    return;
-  }
+  var basePath = interceptor.basePath;
+  var interceptors = allInterceptors[basePath] && allInterceptors[basePath].scopes || [];
 
-  var key          = interceptor._key.split(' '),
-      u            = url.parse(key[1]),
-      hostKey      = u.protocol + '//' + u.host,
-      interceptors = allInterceptors[hostKey] && allInterceptors[hostKey].scopes,
-      thisInterceptor;
-
-  if (interceptors) {
-    for(var i = 0; i < interceptors.length; i++) {
-      thisInterceptor = interceptors[i];
-      if (thisInterceptor === interceptor) {
-        interceptors.splice(i, 1);
-        break;
-      }
-    }
-
-  }
+  interceptors.some(function (thisInterceptor, i) {
+    return (thisInterceptor === interceptor) ? interceptors.splice(i, 1) : false;
+  });
 }
 
 function removeAll() {
@@ -246,7 +231,7 @@ function overrideClientRequest() {
     if (http.OutgoingMessage) http.OutgoingMessage.call(this);
 
     //  Filter the interceptors per request options.
-    var interceptors = interceptorsFor(options)
+    var interceptors = interceptorsFor(options);
 
     if (isOn() && interceptors) {
       debug('using', interceptors.length, 'interceptors');

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -235,7 +235,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       //  For correct matching we need to have correct request headers - if these were specified.
       setRequestHeaders(req, options, interceptor);
     });
-      
+
     interceptor = _.find(interceptors, function(interceptor) {
       return interceptor.match(options, requestBody);
     });

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4219,6 +4219,28 @@ test('match domain using regexp', function (t) {
   });
 });
 
+test('match multiple interceptors with regexp domain (issue-508)', function (t) {
+  var scope = nock(/chainregex/)
+    .get('/')
+    .reply(200, 'Match regex')
+    .get('/')
+    .reply(500, 'Match second intercept');
+
+  mikealRequest.get('http://www.chainregex.com', function(err, res, body) {
+    t.type(err, 'null');
+    t.equal(res.statusCode, 200);
+    t.equal(body, 'Match regex');
+
+    mikealRequest.get('http://www.chainregex.com', function(err, res, body) {
+      t.type(err, 'null');
+      t.equal(res.statusCode, 500);
+      t.equal(body, 'Match second intercept');
+
+      t.end();
+    });
+  });
+});
+
 test('match domain using intercept callback', function (t) {
   var validUrl = [
     '/cats',


### PR DESCRIPTION
From the issue reported on https://github.com/node-nock/nock/issues/508. 

The regex domain interceptor wasn't being removed from the list because the method was using `protocol + host` to find the interceptor in the list. Changed to use `interceptor.basePath` which is reliable for any kind of interceptor.