### PR TITLE
Document replyWithFile using Content-Type header

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ or even as a file:
 ```js
 var scope = nock('http://myapp.iriscouch.com')
                 .get('/')
-                .replyWithFile(200, __dirname + '/replies/user.json');
+                .replyWithFile(200, __dirname + '/replies/user.json', { 'Content-Type': 'application/json' });
 ```
 
 Instead of an object or a buffer you can also pass in a callback to be evaluated for the value of the response body:


### PR DESCRIPTION
I had a use case recently where I forgot to add the Content-Type to nock and it caused another process to interpret the response as empty. Might be useful to demonstrate use of HTTP headers in the README alongside replyWithFile, even though it's also described elsewhere.
