### PR TITLE
remove duplicate definition of replyWithFile()

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -129,16 +129,6 @@ Interceptor.prototype.replyWithFile = function replyWithFile(statusCode, filePat
     return this.reply(statusCode, readStream, headers);
 };
 
-Interceptor.prototype.replyWithFile = function replyWithFile(statusCode, filePath, headers) {
-    if (! fs) {
-        throw new Error('No fs');
-    }
-    var readStream = fs.createReadStream(filePath);
-    readStream.pause();
-    this.filePath = filePath;
-    return this.reply(statusCode, readStream, headers);
-};
-
 
 // Also match request headers
 // https://github.com/pgte/nock/issues/163


### PR DESCRIPTION
`replyWithFile` is defined twice. This removes one unnecessary definition.
