### PR TITLE
Add default nodejs fields to ErroringClientRequest

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -208,6 +208,14 @@ var originalClientRequest;
 
 function ErroringClientRequest(error) {
   if (http.OutgoingMessage) http.OutgoingMessage.call(this);
+
+  this.protocol = 'http';
+  this.hostname = 'localhost';
+  this.port = 80;
+  this.method = 'GET';
+  this.path = '/';
+  this.headers = {};
+
   process.nextTick(function() {
     this.emit('error', error);
   }.bind(this));

--- a/tests/test_net_connect.js
+++ b/tests/test_net_connect.js
@@ -4,6 +4,7 @@ var nock = require('../');
 var test = require('tap').test;
 var mikealRequest = require('request');
 var assert = require('assert');
+var superagent = require('superagent');
 
 test('disable net connect is default', function (t) {
   nock.disableNetConnect();
@@ -14,4 +15,17 @@ test('disable net connect is default', function (t) {
     assert.equal(err.message, 'Nock: Not allow net connect for "google.com:443/"');
     t.end();
   })
+});
+
+test('super agent should work with disable net connect', function (t) {
+  nock.disableNetConnect();
+  var req = superagent
+    .get('http://google.com/')
+    .query({ q: 'testing nock' });
+
+  req.end(function (err, res) {
+    t.equal(err.name, 'NetConnectNotAllowedError');
+    t.end();
+  });
+  nock.enableNetConnect();
 });


### PR DESCRIPTION
This was added specifically because of compatibility issues with superagent.
See: https://github.com/node-nock/nock/issues/211
