### PR TITLE
Use public TravisCI badge icon, which shows failing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nock
 
-[![Build Status](https://secure.travis-ci.org/node-nock/nock.svg?branch=master)](http://travis-ci.org/node-nock/nock?branch=master)
+[![Build Status](https://travis-ci.org/node-nock/nock.svg?branch=master)](https://travis-ci.org/node-nock/nock)
 [![Coverage Status](https://coveralls.io/repos/github/node-nock/nock/badge.svg?branch=master)](https://coveralls.io/github/node-nock/nock?branch=master)
 [![Known Vulnerabilities](https://snyk.io/test/npm/nock/badge.svg)](https://snyk.io/test/npm/nock)
 [![Chat](https://img.shields.io/badge/help-gitter-eb9348.svg?style=flat)](https://gitter.im/node-nock/nock)


### PR DESCRIPTION
Fixes #702 

> The TravisCI badge on the project page shows "Build passing," but the tests are in fact failing – https://travis-ci.org/node-nock/nock. (The src on the badge seems to be incorrect.)
>
> The test that is failing is also failing locally.