### PR TITLE
Fix "`.query` ignored when making a request with no query string" (#610)

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -6,6 +6,7 @@ var mixin           = require('./mixin')
     , _               = require('lodash')
     , debug           = require('debug')('nock.scope')
     , stringify       = require('json-stringify-safe')
+    , url             = require('url')
     , util            = require('util')
     , qs              = require('qs');
 
@@ -23,7 +24,27 @@ function Interceptor(scope, uri, method, requestBody, interceptorOptions) {
     this.scope = scope;
     this.interceptorMatchHeaders = [];
     this.method = method.toUpperCase();
+
+    // if URI includes a query string, separate it to use proper query matching
+    var queryIndex, queryStr;
+    if (_.isString(uri)) {
+        queryStr = url.parse(uri).query;
+        queryIndex = uri.indexOf('?');
+        if (queryStr) {
+            this.query(qs.parse(queryStr));
+        }
+        if (queryIndex >= 0) {
+            uri = uri.substr(0, queryIndex);
+            debug('removed querystring from uri: %s', uri);
+        }
+    }
+    // default to empty query
+    if (typeof this.queries === 'undefined') {
+        this.query();
+    }
+
     this.uri = uri;
+
     this._key = this.method + ' ' + scope.basePath + scope.basePathname + (typeof uri === 'string' ? '' : '/') + uri;
     this.basePath = this.scope.basePath;
     this.path = (typeof uri === 'string') ? scope.basePathname + uri : uri;
@@ -251,22 +272,26 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
         }
     }
 
-    // Match query strings when using query()
+    // Match query strings
     var matchQueries = true;
-    var queryIndex = -1;
+    var queryIndex = path.indexOf('?');
     var queryString;
     var queries;
 
-    if (this.queries && (queryIndex = path.indexOf('?')) !== -1) {
-        queryString = path.slice(queryIndex + 1);
+    debug('this.queries: %j, queryIndex: %j', this.queries, queryIndex);
+
+    // Match if either scope wants a query, or request has a query.
+    // (They should always both match.)
+    queryString = queryIndex === -1 ? '' : path.slice(queryIndex + 1);
+    if (!_.isEmpty(this.queries) || queryString.length) {
         queries = qs.parse(queryString);
 
-        // Only check for query string matches if this.queries is an object
-        if (_.isObject(this.queries)) {
+        debug('compare queries: scoped %j vs request %j', this.queries, queries);
 
-            if(_.isFunction(this.queries)){
+        if (_.isObject(this.queries)) {
+            if (_.isFunction(this.queries)){
                 matchQueries = this.queries(queries);
-            }else {
+            } else {
                 // Make sure that you have an equal number of keys. We are
                 // looping through the passed query params and not the expected values
                 // if the user passes fewer query params than expected but all values
@@ -274,8 +299,6 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
                 // passed query params is equal to the length of expected keys will prevent
                 // us from doing any value checking BEFORE we know if they have all the proper
                 // params
-                debug('this.queries: %j', this.queries);
-                debug('queries: %j', queries);
                 if (_.size(this.queries) !== _.size(queries)) {
                     matchQueries = false;
                 } else {
@@ -284,22 +307,24 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
                         var expVal = self.queries[key];
                         var isMatch = true;
                         if (val === undefined || expVal === undefined) {
-                        isMatch = false;
-                    } else if (expVal instanceof RegExp) {
-                      isMatch = common.matchStringOrRegexp(val, expVal);
-                    } else if (_.isArray(expVal) || _.isObject(expVal)) {
-                      isMatch = _.isEqual(val, expVal);
-                    } else {
-                      isMatch = common.matchStringOrRegexp(val, expVal);
-                    }
-                matchQueries = matchQueries && !!isMatch;
-                });
+                            isMatch = false;
+                        } else if (expVal instanceof RegExp) {
+                            isMatch = common.matchStringOrRegexp(val, expVal);
+                        } else if (_.isArray(expVal) || _.isObject(expVal)) {
+                            isMatch = _.isEqual(val, expVal);
+                        } else {
+                            isMatch = common.matchStringOrRegexp(val, expVal);
+                        }
+                        matchQueries = matchQueries && !!isMatch;
+                    });
                 }
-                debug('matchQueries: %j', matchQueries);
             }
         }
+        debug('matchQueries: %j', matchQueries);
+    }
 
-        // Remove the query string from the path
+    // Remove the query string (or just trailing '?') from the path
+    if (queryIndex >= 0) {
         path = path.substr(0, queryIndex);
     }
 
@@ -396,6 +421,7 @@ Interceptor.prototype.basicAuth = function basicAuth(options) {
  * nock('http://zombo.com').get('/').query({q: 't'});
  */
 Interceptor.prototype.query = function query(queries) {
+    debug('interceptor query, queries: %j', queries);
     this.queries = this.queries || {};
     // Allow all query strings to match this route
     if (queries === true) {

--- a/tests/test_complex_querystring.js
+++ b/tests/test_complex_querystring.js
@@ -5,6 +5,12 @@ var http    = require('http');
 
 test('query with array', function(t) {
     var query1 = { list: [123, 456, 789], a: 'b' };
+    var query2 = { list: [123, 456, 0], a: 'b' };
+
+    nock('https://array-query-string.com')
+        .get('/test')
+        .query(query1)
+        .reply(200, 'success');
 
     request({
         url: 'https://array-query-string.com/test',
@@ -13,17 +19,22 @@ test('query with array', function(t) {
     }, function(error, response, body) {
         t.ok(!error);
         t.deepEqual(body, 'success');
-        t.end();
-    });
 
-    nock('https://array-query-string.com')
-        .get('/test')
-        .query(query1)
-        .reply(200, 'success');
+        request({
+            url: 'https://array-query-string.com/test',
+            qs: query2,
+            method: 'GET'
+        }, function(error, response, body) {
+            t.type(error, Error, 'expect an error');
+            t.match(error.message, 'No match for request');
+            t.end();
+        });
+    });
 });
 
 test('query with array which contains unencoded value ', function(t) {
     var query1 = { list: ['hello%20world', '2hello%20world', 3], a: 'b' };
+    var query2 = { list: ['hello%20worldzz', '2hello%20world', 3], a: 'b' };
 
     nock('https://array-query-string.com')
         .get('/test')
@@ -37,7 +48,16 @@ test('query with array which contains unencoded value ', function(t) {
     }, function(error, response, body) {
         t.ok(!error);
         t.deepEqual(body, 'success');
-        t.end();
+
+        request({
+            url: 'https://array-query-string.com/test',
+            qs: query2,
+            method: 'GET'
+        }, function(error, response, body) {
+            t.type(error, Error, 'expect an error');
+            t.match(error.message, 'No match for request');
+            t.end();
+        });
     });
 });
 
@@ -55,7 +75,15 @@ test('query with array which contains pre-encoded values ', function(t) {
     }, function(error, response, body) {
         t.ok(!error);
         t.deepEqual(body, 'success');
-        t.end();
+
+        request({
+            url: 'https://array-query-string.com/test?list%5B0%5D=hello%20world&list%5B1%5D=2hello%20worldzz',
+            method: 'GET'
+        }, function(error, response, body) {
+            t.type(error, Error, 'expect an error');
+            t.match(error.message, 'No match for request');
+            t.end();
+        });
     });
 });
 
@@ -65,6 +93,13 @@ test('query with object', function(t) {
             b: ['c', 'd']
         },
         e: [1, 2, 3, 4]
+    };
+
+    var query2 = {
+        a: {
+            b: ['c', 'd']
+        },
+        e: [1, 2, 3, 4, 5]
     };
 
     nock('https://object-query-string.com')
@@ -79,7 +114,16 @@ test('query with object', function(t) {
     }, function(error, response, body) {
         t.ok(!error);
         t.deepEqual(body, 'success');
-        t.end();
+
+        request({
+            url: 'https://array-query-string.com/test',
+            qs: query2,
+            method: 'GET'
+        }, function(error, response, body) {
+            t.type(error, Error, 'expect an error');
+            t.match(error.message, 'No match for request');
+            t.end();
+        });
     });
 });
 

--- a/tests/test_encode_querystring.js
+++ b/tests/test_encode_querystring.js
@@ -26,7 +26,15 @@ test('encode query string', function(t) {
     }, function(error, response, body) {
       t.type(error, Error, 'expect an error');
       t.match(error.message, 'No match for request');
-      t.end();
+
+      request({
+        url: 'https://encodeland.com/test',
+        method: 'GET'
+      }, function(error, response, body) {
+        t.type(error, Error, 'expect an error');
+        t.match(error.message, 'No match for request');
+        t.end();
+      });
     });
   });
 });

--- a/tests/test_encode_querystring.js
+++ b/tests/test_encode_querystring.js
@@ -4,6 +4,7 @@ var test    = require('tap').test;
 
 test('encode query string', function(t) {
   var query1 = { q: '(nodejs)' };
+  var query2 = { q: '(wrong)' };
 
   nock('https://encodeland.com')
     .get('/test')
@@ -17,6 +18,15 @@ test('encode query string', function(t) {
   }, function(error, response, body) {
     t.ok(!error);
     t.deepEqual(body, 'success');
-    t.end();
+
+    request({
+      url: 'https://encodeland.com/test',
+      qs: query2,
+      method: 'GET'
+    }, function(error, response, body) {
+      t.type(error, Error, 'expect an error');
+      t.match(error.message, 'No match for request');
+      t.end();
+    });
   });
 });

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4725,6 +4725,18 @@ test('query() with "{}" will allow a match against ending in ?', function (t) {
   })
 });
 
+test('query() will not match when there is no query string in the request', function (t) {
+  var scope = nock('https://d.com')
+    .get('/a')
+    .query({foo: 'bar'})
+    .reply(200);
+
+  mikealRequest('https://d.com/a', function(err, res) {
+    t.equal(err.message.trim(), 'Nock: No match for request GET https://d.com/a');
+    t.end();
+  })
+});
+
 test('query() with a function, function called with actual queryObject',function(t){
   var queryObject;
 
@@ -4747,13 +4759,13 @@ test('query() with a function, function called with actual queryObject',function
 });
 
 test('query() with a function, function return true the query treat as matched',function(t){
-  var alwasyTrue = function(){
+  var alwaysTrue = function(){
     return true;
   };
 
   var scope = nock('http://google.com')
     .get('/')
-    .query(alwasyTrue)
+    .query(alwaysTrue)
     .reply(200);
 
   mikealRequest('http://google.com/?igore=the&actual=query', function(err, res) {
@@ -4764,22 +4776,20 @@ test('query() with a function, function return true the query treat as matched',
 });
 
 test('query() with a function, function return false the query treat as Un-matched',function(t){
-
-  var alwayFalse = function(){
+  var alwaysFalse = function(){
     return false;
   };
 
   var scope = nock('http://google.com')
     .get('/')
-    .query(alwayFalse)
+    .query(alwaysFalse)
     .reply(200);
 
-  mikealRequest('http://google.com/?i=should&pass=?', function(err, res) {
-    t.equal(err.message.trim(), 'Nock: No match for request GET http://google.com/?i=should&pass=?');
+  mikealRequest('http://google.com/?i=should&pass=', function(err, res) {
+    t.equal(err.message.trim(), 'Nock: No match for request GET http://google.com/?i=should&pass=');
     t.end();
   })
 });
-
 
 test('query() will not match when a query string does not match name=value', function (t) {
   var scope = nock('https://c.com')

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4844,6 +4844,7 @@ test('query() will not match when a query string has fewer correct values than e
 });
 
 test('query() will not match when the path has no query', function (t) {
+  nock.cleanAll();
   var scope = nock('http://google.com')
     .get('/')
     .query({ foo: 'bar' })

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1297,9 +1297,7 @@ test("reply with file with mikeal/request", function(t) {
 
   var options = { uri: 'http://www.files.com/', onResponse: true };
   mikealRequest('http://www.files.com/', function(err, res, body) {
-    if (err) {
-      throw err;
-    }
+    t.error(err);
 
     res.setEncoding('utf8');
     t.equal(res.statusCode, 200);
@@ -2708,7 +2706,7 @@ test('enable real HTTP request only for google.com, via string', function(t) {
   nock.enableNetConnect('google.com');
 
   http.get('http://google.com.br/').on('error', function(err) {
-    throw err;
+    t.error(err);
   });
 
   http.get('http://www.amazon.com', function(res) {
@@ -2725,7 +2723,7 @@ test('enable real HTTP request only for google.com, via regexp', function(t) {
   nock.enableNetConnect(/google\.com/);
 
   http.get('http://google.com.br/').on('error', function(err) {
-    throw err;
+    t.error(err);
   });
 
   http.get('http://www.amazon.com', function(res) {
@@ -4596,7 +4594,7 @@ test('query() matches a query string of the same name=value', function (t) {
     .reply(200);
 
   mikealRequest('http://google.com/?foo=bar', function(err, res) {
-    if (err) throw err;
+    t.error(err);
     t.equal(res.statusCode, 200);
     t.end();
   })
@@ -4609,7 +4607,7 @@ test('query() matches multiple query strings of the same name=value', function (
     .reply(200);
 
   mikealRequest('http://google.com/?foo=bar&baz=foz', function(err, res) {
-    if (err) throw err;
+    t.error(err);
     t.equal(res.statusCode, 200);
     t.end();
   })
@@ -4622,7 +4620,7 @@ test('query() matches multiple query strings of the same name=value regardless o
     .reply(200);
 
   mikealRequest('http://google.com/?baz=foz&foo=bar', function(err, res) {
-    if (err) throw err;
+    t.error(err);
     t.equal(res.statusCode, 200);
     t.end();
   })
@@ -4635,7 +4633,7 @@ test('query() matches query values regardless of their type of declaration', fun
     .reply(200);
 
   mikealRequest('http://google.com/?num=1&bool=true&empty=&str=fou', function(err, res) {
-    if (err) throw err;
+    t.error(err);
     t.equal(res.statusCode, 200);
     t.end();
   })
@@ -4648,7 +4646,7 @@ test('query() matches a query string using regexp', function (t) {
     .reply(200);
 
   mikealRequest('http://google.com/?foo=bar', function(err, res) {
-    if (err) throw err;
+    t.error(err);
     t.equal(res.statusCode, 200);
     t.end();
   })
@@ -4668,7 +4666,7 @@ test('query() matches a query string that contains special RFC3986 characters', 
   };
 
   mikealRequest(options, function(err, res) {
-    if (err) throw err;
+    t.error(err);
     t.equal(res.statusCode, 200);
     t.end();
   })
@@ -4693,7 +4691,7 @@ test('query() matches a query string with pre-encoded values', function (t) {
     .reply(200);
 
   mikealRequest('http://google.com?foo=hello%20world', function(err, res) {
-    if (err) throw err;
+    t.error(err);
     t.equal(res.statusCode, 200);
     t.end();
   })
@@ -4706,7 +4704,7 @@ test('query() with "true" will allow all query strings to pass', function (t) {
     .reply(200);
 
   mikealRequest('http://google.com/?foo=bar&a=1&b=2', function(err, res) {
-    if (err) throw err;
+    t.error(err);
     t.equal(res.statusCode, 200);
     t.end();
   })
@@ -4719,7 +4717,7 @@ test('query() with "{}" will allow a match against ending in ?', function (t) {
     .reply(200);
 
   mikealRequest('http://querystringmatchland.com/noquerystring?', function(err, res) {
-    if (err) throw err;
+    t.error(err);
     t.equal(res.statusCode, 200);
     t.end();
   })
@@ -4732,6 +4730,7 @@ test('query() will not match when there is no query string in the request', func
     .reply(200);
 
   mikealRequest('https://d.com/a', function(err, res) {
+    t.type(err, Error);
     t.equal(err.message.trim(), 'Nock: No match for request GET https://d.com/a');
     t.end();
   })
@@ -4751,7 +4750,7 @@ test('query() with a function, function called with actual queryObject',function
     .reply(200);
 
   mikealRequest('http://google.com/?foo=bar&a=1&b=2', function(err, res) {
-    if (err) throw err;
+    t.error(err);
     t.deepEqual(queryObject,{foo:'bar',a:'1',b:'2'});
     t.equal(res.statusCode, 200);
     t.end();
@@ -4769,7 +4768,7 @@ test('query() with a function, function return true the query treat as matched',
     .reply(200);
 
   mikealRequest('http://google.com/?igore=the&actual=query', function(err, res) {
-    if (err) throw err;
+    t.error(err);
     t.equal(res.statusCode, 200);
     t.end();
   })
@@ -4840,6 +4839,19 @@ test('query() will not match when a query string has fewer correct values than e
 
   mikealRequest('http://google.com/?num=1str=fou', function(err, res) {
     t.equal(err.message.trim(), 'Nock: No match for request GET http://google.com/?num=1str=fou');
+    t.end();
+  })
+});
+
+test('query() will not match when the path has no query', function (t) {
+  var scope = nock('http://google.com')
+    .get('/')
+    .query({ foo: 'bar' })
+    .reply(200);
+
+  mikealRequest('http://google.com', function(err, res) {
+    t.type(err, Error);
+    t.match(err.message, 'Nock: No match for request');
     t.end();
   })
 });


### PR DESCRIPTION
This fixes issue #610, _`.query` ignored when making a request with no query string_.

Issues still outstanding:
- Another test is failing, see https://github.com/node-nock/nock/pull/703
- The `tap` framework used for testing isn't cleaning up between tests, and nock's scope seems to be leaking from test to test. I'll file a separate issue for this.
