### PR TITLE
Update PendingMocks when an interceptor is removed

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -188,8 +188,10 @@ function removeInterceptor(options) {
   if (allInterceptors[baseUrl] && allInterceptors[baseUrl].scopes.length > 0) {
     if (key) {
       for (var i = 0; i < allInterceptors[baseUrl].scopes.length; i++) {
-        if (allInterceptors[baseUrl].scopes[i]._key === key) {
+        var interceptor = allInterceptors[baseUrl].scopes[i];
+        if (interceptor._key === key) {
           allInterceptors[baseUrl].scopes.splice(i, 1);
+          interceptor.scope.remove(key, interceptor);
           break;
         }
       }

--- a/tests/browserify-public/browserify-bundle.js
+++ b/tests/browserify-public/browserify-bundle.js
@@ -967,8 +967,10 @@ function removeInterceptor(options) {
   if (allInterceptors[baseUrl] && allInterceptors[baseUrl].scopes.length > 0) {
     if (key) {
       for (var i = 0; i < allInterceptors[baseUrl].scopes.length; i++) {
-        if (allInterceptors[baseUrl].scopes[i]._key === key) {
+        var interceptor = allInterceptors[baseUrl].scopes[i];
+        if (interceptor._key === key) {
           allInterceptors[baseUrl].scopes.splice(i, 1);
+          interceptor.scope.remove(key, interceptor);
           break;
         }
       }
@@ -1310,17 +1312,6 @@ Interceptor.prototype.replyWithFile = function replyWithFile(statusCode, filePat
     this.filePath = filePath;
     return this.reply(statusCode, readStream, headers);
 };
-
-Interceptor.prototype.replyWithFile = function replyWithFile(statusCode, filePath, headers) {
-    if (! fs) {
-        throw new Error('No fs');
-    }
-    var readStream = fs.createReadStream(filePath);
-    readStream.pause();
-    this.filePath = filePath;
-    return this.reply(statusCode, readStream, headers);
-};
-
 
 // Also match request headers
 // https://github.com/pgte/nock/issues/163

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4325,6 +4325,24 @@ test('remove interceptor removes given interceptor', function(t) {
 });
 
 
+test('remove interceptor removes interceptor from pending requests', function(t) {
+  var givenInterceptor = nock('http://example.org')
+    .get('/somepath');
+  var scope = givenInterceptor
+    .reply(200, 'hey');
+
+  var mocks = scope.pendingMocks();
+  t.deepEqual(mocks, ['GET http://example.org:80/somepath']);
+
+  var result = nock.removeInterceptor(givenInterceptor);
+  t.ok(result, 'result should be true');
+
+  var mocksAfterRemove = scope.pendingMocks();
+  t.deepEqual(mocksAfterRemove, [ ]);
+  t.end();
+});
+
+
 test('remove interceptor removes given interceptor for https', function(t) {
   var givenInterceptor = nock('https://example.org')
     .get('/somepath');


### PR DESCRIPTION
Currently when you call `nock.removeInterceptor(interceptor)` it stops that interceptor from doing any more intercepting, but doesn't remove it from `pendingMocks()` (this is part of https://github.com/node-nock/nock/issues/600).

This fixes that, by updating the interceptor's scope to remove it properly. I.e. with this change, pendingMocks is now empty at the end, as expected:

```javascript
var interceptor = nock('http://example.org').get('/somepath');
var scope = interceptor.reply(200, 'hey');

nock.removeInterceptor(interceptor);

scope.pendingMocks() // Empty;
```

It looks like there's a separate issue in #600 that I haven't looked at about how `nock.pendingMocks()` behaves with scope reuse. This patch doesn't fix that (and I'm probably not going to, since it doesn't affect me).

This patch also includes an unrelated change to remove replyWithFile from browserify-bundle. Not really sure why, but I'd guess this means somebody else made that change in lib/ recently and forgot to commit the corresponding browserify-bundle.