### PR TITLE
Add optionally() and make isDone and pendingMocks consistent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ For instance, if a module performs HTTP requests to a CouchDB server or makes HT
     - [Path filtering](#path-filtering)
     - [Request Body filtering](#request-body-filtering)
     - [Request Headers Matching](#request-headers-matching)
+    - [Optional Requests](#optional-requests)
     - [Allow __unmocked__ requests on a mocked hostname](#allow-unmocked-requests-on-a-mocked-hostname)
 - [Expectations](#expectations)
     - [.isDone()](#isdone)
@@ -808,6 +809,23 @@ var scope = nock('http://api.myservice.com')
                 .reply(200, {
                   data: 'hello world'
                 })
+```
+
+## Optional Requests
+
+By default every mocked request is expected to be made exactly once, and until it is it'll appear in `scope.pendingMocks()`, and `scope.isDone()` will return false (see [expectations](#expectations)). In many cases this is fine, but in some (especially cross-test setup code) it's useful to be able to mock a request that may or may not happen. You can do this with `optionally()`. Optional requests do not appear in `pendingMocks()`, and `isDone()` will return true for scopes with only optional requests pending.
+
+```js
+var example = nock("http://example.com");
+example.pendingMocks() // []
+example.get("/pathA").reply(200);
+example.pendingMocks() // ["GET http://example.com:80/path"]
+
+// ...After a request to example.com/pathA:
+example.pendingMocks() // []
+
+example.get("/pathB").optionally().reply(200);
+example.pendingMocks() // []
 ```
 
 ## Allow __unmocked__ requests on a mocked hostname

--- a/README.md
+++ b/README.md
@@ -813,7 +813,7 @@ var scope = nock('http://api.myservice.com')
 
 ## Optional Requests
 
-By default every mocked request is expected to be made exactly once, and until it is it'll appear in `scope.pendingMocks()`, and `scope.isDone()` will return false (see [expectations](#expectations)). In many cases this is fine, but in some (especially cross-test setup code) it's useful to be able to mock a request that may or may not happen. You can do this with `optionally()`. Optional requests do not appear in `pendingMocks()`, and `isDone()` will return true for scopes with only optional requests pending.
+By default every mocked request is expected to be made exactly once, and until it is it'll appear in `scope.pendingMocks()`, and `scope.isDone()` will return false (see [expectations](#expectations)). In many cases this is fine, but in some (especially cross-test setup code) it's useful to be able to mock a request that may or may not happen. You can do this with `optionally()`. Optional requests are consumed just like normal ones once matched, but they do not appear in `pendingMocks()`, and `isDone()` will return true for scopes with only optional requests pending.
 
 ```js
 var example = nock("http://example.com");

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ For instance, if a module performs HTTP requests to a CouchDB server or makes HT
     - [.cleanAll()](#cleanall)
     - [.persist()](#persist)
     - [.pendingMocks()](#pendingmocks)
+    - [.activeMocks()](#activemocks)    
 - [Logging](#logging)
 - [Restoring](#restoring)
 - [Turning Nock Off (experimental!)](#turning-nock-off-experimental)
@@ -916,6 +917,22 @@ It is also available in the global scope:
 
 ```js
 console.error('pending mocks: %j', nock.pendingMocks());
+```
+
+## .activeMocks()
+
+You can see every mock that is currently active (i.e. might potentially reply to requests) in a scope using `scope.activeMocks()`. A mock is active if it is pending, optional but not yet completed, or persisted. Mocks that have intercepted their requests and are no longer doing anything are the only mocks which won't appear here.
+
+You probably don't need to use this - it mainly exists as a mechanism to recreate the previous (now-changed) behavior of `pendingMocks()`.
+
+```js
+console.error('active mocks: %j', scope.activeMocks());
+```
+
+It is also available in the global scope:
+
+```js
+console.error('active mocks: %j', nock.activeMocks());
 ```
 
 # Logging

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -293,22 +293,32 @@ function isActive() {
 
 }
 
-function isDone() {
-  return _.every(allInterceptors, function(interceptors) {
-    return _.every(interceptors.scopes, function(interceptor) {
-      return interceptor.__nock_scope.isDone();
-    });
-  });
-}
-
-function pendingMocks() {
+function interceptorScopes() {
   return _.reduce(allInterceptors, function(result, interceptors) {
     for (var interceptor in interceptors.scopes) {
-      result = result.concat(interceptors.scopes[interceptor].__nock_scope.pendingMocks());
+      result = result.concat(interceptors.scopes[interceptor].__nock_scope);
     }
 
     return result;
   }, []);
+}
+
+function isDone() {
+  return _.every(interceptorScopes(), function(scope) {
+    return scope.isDone();
+  });
+}
+
+function pendingMocks() {
+  return _.flatten(_.map(interceptorScopes(), function(scope) {
+    return scope.pendingMocks();
+  }));
+}
+
+function activeMocks() {
+  return _.flatten(_.map(interceptorScopes(), function(scope) {
+    return scope.activeMocks();
+  }));
 }
 
 function activate() {
@@ -390,6 +400,7 @@ module.exports.activate = activate;
 module.exports.isActive = isActive;
 module.exports.isDone = isDone;
 module.exports.pendingMocks = pendingMocks;
+module.exports.activeMocks = activeMocks;
 module.exports.enableNetConnect = enableNetConnect;
 module.exports.disableNetConnect = disableNetConnect;
 module.exports.overrideClientRequest = overrideClientRequest;

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -40,6 +40,13 @@ function Interceptor(scope, uri, method, requestBody, interceptorOptions) {
 
     this.delayInMs = 0;
     this.delayConnectionInMs = 0;
+
+    this.optional = false;
+}
+
+Interceptor.prototype.optionally = function optionally() {
+    this.optional = true;
+    return this;
 }
 
 Interceptor.prototype.replyWithError = function replyWithError(errorMessage) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -125,8 +125,7 @@ Scope.prototype.pendingMocks = function pendingMocks() {
     var interceptorList = self.keyedInterceptors[key];
     var pendingInterceptors = interceptorList.filter(function (interceptor) {
       var persistedAndUsed = self._persist && interceptor.interceptionCounter > 0;
-      var requireDone = interceptor.options.requireDone === undefined || interceptor.options.requireDone === true;
-      return !persistedAndUsed && requireDone;
+      return !persistedAndUsed && !interceptor.optional;
     });
     return pendingInterceptors.length > 0;
   });

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -135,6 +135,13 @@ Scope.prototype.pendingMocks = function pendingMocks() {
   return pendingInterceptorKeys;
 };
 
+// Returns all keyedInterceptors that are active.
+// This incomplete interceptors, persisted but complete interceptors, and
+// optional interceptors, but not non-persisted and completed interceptors.
+Scope.prototype.activeMocks = function activeMocks() {
+  return Object.keys(this.keyedInterceptors);
+}
+
 Scope.prototype.isDone = function isDone() {
   var self = this;
   // if nock is turned off, it always says it's done
@@ -336,6 +343,7 @@ module.exports = extend(startScope, {
   isActive: globalIntercept.isActive,
   isDone: globalIntercept.isDone,
   pendingMocks: globalIntercept.pendingMocks,
+  activeMocks: globalIntercept.activeMocks,
   removeInterceptor: globalIntercept.removeInterceptor,
   disableNetConnect: globalIntercept.disableNetConnect,
   enableNetConnect: globalIntercept.enableNetConnect,

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -119,7 +119,19 @@ Scope.prototype.delete = function _delete(uri, requestBody, options) {
 };
 
 Scope.prototype.pendingMocks = function pendingMocks() {
-  return Object.keys(this.keyedInterceptors);
+  var self = this;
+
+  var pendingInterceptorKeys = Object.keys(this.keyedInterceptors).filter(function (key) {
+    var interceptorList = self.keyedInterceptors[key];
+    var pendingInterceptors = interceptorList.filter(function (interceptor) {
+      var persistedAndUsed = self._persist && interceptor.interceptionCounter > 0;
+      var requireDone = interceptor.options.requireDone === undefined || interceptor.options.requireDone === true;
+      return !persistedAndUsed && requireDone;
+    });
+    return pendingInterceptors.length > 0;
+  });
+
+  return pendingInterceptorKeys;
 };
 
 Scope.prototype.isDone = function isDone() {
@@ -127,30 +139,7 @@ Scope.prototype.isDone = function isDone() {
   // if nock is turned off, it always says it's done
   if (! globalIntercept.isOn()) { return true; }
 
-  var keys = Object.keys(this.keyedInterceptors);
-  if (keys.length === 0) {
-    return true;
-  } else {
-    var doneHostCount = 0;
-
-    keys.forEach(function(key) {
-      var doneInterceptorCount = 0;
-
-      self.keyedInterceptors[key].forEach(function(interceptor) {
-        var isRequireDoneDefined = !_.isUndefined(interceptor.options.requireDone);
-        if (isRequireDoneDefined && interceptor.options.requireDone === false) {
-          doneInterceptorCount += 1;
-        } else if (self._persist && interceptor.interceptionCounter > 0) {
-          doneInterceptorCount += 1;
-        }
-      });
-
-      if (doneInterceptorCount === self.keyedInterceptors[key].length ) {
-        doneHostCount += 1;
-      }
-    });
-    return (doneHostCount === keys.length);
-  }
+  return this.pendingMocks().length === 0;
 };
 
 Scope.prototype.done = function done() {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -124,6 +124,8 @@ Scope.prototype.pendingMocks = function pendingMocks() {
   var pendingInterceptorKeys = Object.keys(this.keyedInterceptors).filter(function (key) {
     var interceptorList = self.keyedInterceptors[key];
     var pendingInterceptors = interceptorList.filter(function (interceptor) {
+      // TODO: This assumes that completed mocks are removed from the keyedInterceptors list
+      // (when persistence is off). We should change that (and this) in future.
       var persistedAndUsed = self._persist && interceptor.interceptionCounter > 0;
       return !persistedAndUsed && !interceptor.optional;
     });

--- a/tests/browserify-public/browserify-bundle.js
+++ b/tests/browserify-public/browserify-bundle.js
@@ -1219,6 +1219,13 @@ function Interceptor(scope, uri, method, requestBody, interceptorOptions) {
 
     this.delayInMs = 0;
     this.delayConnectionInMs = 0;
+
+    this.optional = false;
+}
+
+Interceptor.prototype.optionally = function optionally() {
+    this.optional = true;
+    return this;
 }
 
 Interceptor.prototype.replyWithError = function replyWithError(errorMessage) {
@@ -2823,8 +2830,7 @@ Scope.prototype.pendingMocks = function pendingMocks() {
     var interceptorList = self.keyedInterceptors[key];
     var pendingInterceptors = interceptorList.filter(function (interceptor) {
       var persistedAndUsed = self._persist && interceptor.interceptionCounter > 0;
-      var requireDone = interceptor.requireDone === undefined || interceptor.requireDone === true;
-      return !persistedAndUsed && requireDone;
+      return !persistedAndUsed && !interceptor.optional;
     });
     return pendingInterceptors.length > 0;
   });

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2314,6 +2314,46 @@ test('isDone is true with optional mocks outstanding', function(t) {
   t.end();
 });
 
+test('optional but persisted mocks persist, but never appear as pending', function(t) {
+  var scope = nock('http://example.com')
+    .get('/123')
+    .optionally()
+    .reply(200)
+    .persist();
+
+  t.deepEqual(nock.pendingMocks(), []);
+  var req = http.get({host: 'example.com', path: '/123'}, function(res) {
+    t.assert(res.statusCode === 200, "should mock first request");
+    t.deepEqual(nock.pendingMocks(), []);
+
+    var req = http.get({host: 'example.com', path: '/123'}, function(res) {
+      t.assert(res.statusCode === 200, "should mock second request");
+      t.deepEqual(nock.pendingMocks(), []);
+      t.end();
+    });
+  });
+});
+
+test('optional repeated mocks execute repeatedly, but never appear as pending', function(t) {
+  var scope = nock('http://example.com')
+    .get('/456')
+    .optionally()
+    .times(2)
+    .reply(200);
+
+  t.deepEqual(nock.pendingMocks(), []);
+  var req = http.get({host: 'example.com', path: '/456'}, function(res) {
+    t.assert(res.statusCode === 200, "should mock first request");
+    t.deepEqual(nock.pendingMocks(), []);
+
+    var req = http.get({host: 'example.com', path: '/456'}, function(res) {
+      t.assert(res.statusCode === 200, "should mock second request");
+      t.deepEqual(nock.pendingMocks(), []);
+      t.end();
+    });
+  });
+});
+
 test('username and password works', function(t) {
   var scope = nock('http://passwordyy.com')
     .get('/')

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2444,6 +2444,28 @@ test('persists interceptors', function(t) {
   }).end();
 });
 
+test('Persisted interceptors are in pendingMocks initially', function(t) {
+  var scope = nock('http://example.com')
+    .get('/abc')
+    .reply(200, "Persisted reply")
+    .persist();
+
+  t.deepEqual(scope.pendingMocks(), ["GET http://example.com:80/abc"]);
+  t.end();
+});
+
+test('Persisted interceptors are not in pendingMocks after the first request', function(t) {
+  var scope = nock('http://example.com')
+    .get('/def')
+    .reply(200, "Persisted reply")
+    .persist();
+
+  http.get('http://example.com/def', function(res) {
+    t.deepEqual(scope.pendingMocks(), []);
+    t.end();
+  });
+});
+
 test("persist reply with file", function(t) {
   var scope = nock('http://www.filereplier.com')
     .persist()

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -622,22 +622,6 @@ test("isDone", function(t) {
   req.end();
 });
 
-test("requireDone", function(t) {
-  var scope = nock('http://www.google.com')
-    .get('/', false, { requireDone: false })
-    .reply(200, "Hello World!");
-
-  t.ok(scope.isDone(), "done when a requireDone is set to false");
-
-  scope.get('/', false, { requireDone: true})
-       .reply(200, "Hello World!");
-
-  t.notOk(scope.isDone(), "not done when a requireDone is explicitly set to true");
-
-  nock.cleanAll()
-  t.end();
-});
-
 test("request headers exposed", function(t) {
 
   var scope = nock('http://www.headdy.com')
@@ -2295,6 +2279,39 @@ test('pending mocks works', function(t) {
     t.deepEqual(nock.pendingMocks(), []);
     t.end();
   });
+});
+
+test('pending mocks doesn\'t include optional mocks', function(t) {
+  var scope = nock('http://example.com')
+    .get('/nonexistent')
+    .optionally()
+    .reply(200);
+
+  t.deepEqual(nock.pendingMocks(), []);
+  t.end();
+});
+
+test('optional mocks are still functional', function(t) {
+  var scope = nock('http://example.com')
+    .get('/abc')
+    .optionally()
+    .reply(200);
+
+  var req = http.get({host: 'example.com', path: '/abc'}, function(res) {
+    t.assert(res.statusCode === 200, "should still mock requests");
+    t.deepEqual(nock.pendingMocks(), []);
+    t.end();
+  });
+});
+
+test('isDone is true with optional mocks outstanding', function(t) {
+  var scope = nock('http://example.com')
+    .get('/abc')
+    .optionally()
+    .reply(200);
+
+  t.ok(scope.isDone());
+  t.end();
 });
 
 test('username and password works', function(t) {
@@ -4423,7 +4440,6 @@ test('remove interceptor for not found resource', function(t) {
 });
 
 test('isDone() must consider repeated responses', function(t) {
-
   var scope = nock('http://www.example.com')
     .get('/')
     .times(2)
@@ -4453,7 +4469,6 @@ test('isDone() must consider repeated responses', function(t) {
       t.end();
     });
   });
-
 });
 
 test('you must setup an interceptor for each request', function(t) {


### PR DESCRIPTION
This PR adds `optionally()`, so you can define mocks that might happen, but not worry about it if they don't (I'm using this for some common test setup where for almost every test in need a basic request mocked out, but not for all of them).

Along the way I noticed `isDone()` and `pendingMocks()` weren't actually consistent. Only `isDone()` ever considered persisted mocks to be 'done' (they stayed in `pendingMocks()` forever), and only `isDone()` supported `options.requireDone` (see below). I've now made them consistent so, tidied the implementations together, and simplified this significantly on the way.

There was an existing feature sort-of like `optionally()` already present: you could pass `requireDone: false` as an option to an interceptor. Passing as an option is less nice UX for my case, but more problematically it was previously inconsistent between pendingMocks (which ignored it) and isDone (which didn't), it wasn't undocumented _anywhere_, and it doesn't appear to have ever been used (no results in google or in code on github that aren't from direct copies of this codebase). I've removed this, since `optionally()` does the same thing. Could keep it, your call, but I'd just let it go IMO.