### PR TITLE
Fixes regression introduced by #719

### DIFF
--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -57,7 +57,7 @@ function deepEqualExtended(spec, body) {
   if (spec && spec.constructor === RegExp) {
     return spec.test(body);
   }
-  if (spec && spec.constructor === Object || spec.constructor === Array && body) {
+  if (spec && (spec.constructor === Object || spec.constructor === Array) && body) {
     var keys = Object.keys(spec);
     for (var i = 0; i < keys.length; i++) {
       if (!deepEqualExtended(spec[keys[i]], body[keys[i]])) {

--- a/tests/test_body_match.js
+++ b/tests/test_body_match.js
@@ -47,3 +47,22 @@ test('match body with regex inside array', function (t) {
     t.end();
   });
 })
+
+test('match body with empty object inside', function (t) {
+
+  nock('http://encodingsareus.com')
+    .post('/', { obj: {}})
+    .reply(200);
+
+  mikealRequest({
+    url: 'http://encodingsareus.com/',
+    method: 'post',
+    json: {
+      obj: {}
+    },
+  }, function(err, res) {
+    if (err) throw err;
+    assert.equal(res.statusCode, 200);
+    t.end();
+  });
+})


### PR DESCRIPTION
This adds a test for empty objects in the body and spec.

It also fixes a regression that would cause the library to throw an error if an empty object was passed in the body.

CC @vrinek