### PR TITLE
Fix this pointer on "socket" event

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -193,7 +193,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
   req.once = req.on = function(event, listener) {
     // emit a fake socket.
     if (event == 'socket') {
-      listener(req.socket);
+      listener.call(req, req.socket);
       req.socket.emit('connect', req.socket);
       req.socket.emit('secureConnect', req.socket);
     }

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4212,6 +4212,7 @@ test('request emits socket', function(t) {
 
   var req = http.get('http://gotzsocketz.com');
   req.once('socket', function(socket) {
+    t.equal(this, req);
     t.type(socket, Object);
     t.type(socket.getPeerCertificate(), 'string');
     t.end();


### PR DESCRIPTION
This makes behavior consistent with the Node.js HTTP module
(https://github.com/nodejs/node/blob/v6.0.0/lib/_http_client.js#L541).