### PR TITLE
Fix README intercept example

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ Nock supports any HTTP verb, and it has convenience methods for the GET, POST, P
 You can intercept any HTTP verb using `.intercept(path, verb [, requestBody [, options]])`:
 
 ```js
-scope('http://my.domain.com')
+var scope = nock('http://my.domain.com')
   .intercept('/path', 'PATCH')
   .reply(304);
 ```


### PR DESCRIPTION
I'm not sure, but I couldn't figure out where `scope` method came from... So I propose this.
Please close this PR if I'm wrong.