### PR TITLE
Emit socket event with correct context

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -193,7 +193,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
   req.once = req.on = function(event, listener) {
     // emit a fake socket.
     if (event == 'socket') {
-      listener(req.socket);
+      listener.call(req, req.socket);
       req.socket.emit('connect', req.socket);
       req.socket.emit('secureConnect', req.socket);
     }

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4212,6 +4212,7 @@ test('request emits socket', function(t) {
 
   var req = http.get('http://gotzsocketz.com');
   req.once('socket', function(socket) {
+    t.equal(req, this);
     t.type(socket, Object);
     t.type(socket.getPeerCertificate(), 'string');
     t.end();


### PR DESCRIPTION
Many modules, such as restify, timed-out, follow-redirects etc depend on the `socket` event being emitted. This happens as it is, but it is called without a `this`-binding, which should be set to the request. This breaks for instance the `follow-redirects` module when using nock.
