### PR TITLE
Fix request timeout no working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 coverage
 .nyc_output/
 tests/browserify-public/browserify-bundle.js
+.vscode/

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -133,6 +133,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
   };
 
   req.socket = response.socket = Socket({ proto: options.proto });
+  req.socket.connecting = true;
 
   req.write = function(buffer, encoding) {
     debug('write', arguments);
@@ -194,8 +195,6 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     // emit a fake socket.
     if (event == 'socket') {
       listener.call(req, req.socket);
-      req.socket.emit('connect', req.socket);
-      req.socket.emit('secureConnect', req.socket);
     }
 
     EventEmitter.prototype.on.call(this, event, listener);
@@ -490,6 +489,9 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
           if (aborted) { return; }
 
           debug('emitting response');
+
+          req.socket.emit('connect', req.socket);
+          req.socket.emit('secureConnect', req.socket);
 
           if (typeof cb === 'function') {
             debug('callback with response');

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "node-static": "^0.7.7",
     "nyc": "^10.0.0",
     "pre-commit": "1.1.2",
-    "request": "2.71.0",
+    "request": "2.79.0",
     "request-promise": "^2.0.1",
     "restify": "^4.0.4",
     "restler": "3.4.0",

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4234,12 +4234,12 @@ test('socket emits connect and secureConnect', function(t) {
 
   req.on('socket', function(socket) {
     socket.once('connect', function() {
-      req.end();
       t.ok(true);
     });
     socket.once('secureConnect', function() {
       t.ok(true);
     });
+    req.end();
   });
 
   req.once('response', function(res) {


### PR DESCRIPTION
This PR fixed #754 and #739

There are two changes:
1. Set `socket.connecting` to `true` to allow `request` module creates timeout timer.
2. Emit `ClientRequest.connect` event after connection delay, just before sending response. Before modification, it emits too early and make `request` module clears the connection timeout timer.

