### PR TITLE
[Fix] error on nock.back options output_objects

### DIFF
--- a/lib/back.js
+++ b/lib/back.js
@@ -168,7 +168,8 @@ var record = {
 
 
   finish: function (fixture, options, context) {
-    if( context.isRecording ) {
+    if(context.isRecording) {
+
       var outputs = recorder.outputs();
 
       if( typeof options.afterRecord === 'function' ) {
@@ -177,6 +178,10 @@ var record = {
 
       outputs = JSON.stringify(outputs, null, 4);
       debug('recorder outputs:', outputs);
+
+      if(options && options.recorder && options.recorder.output_objects === false) {
+        return;
+      }
 
       mkdirp.sync(path.dirname(fixture));
       fs.writeFileSync(fixture, outputs);

--- a/tests/test_back_2.js
+++ b/tests/test_back_2.js
@@ -69,6 +69,24 @@ test('passes custom options to recorder', {skip: process.env.AIRPLANE}, function
   rimrafOnEnd(t);
 });
 
+test('recorder output_objects is false', {skip: process.env.AIRPLANE}, function(t) {
+  nockBack('recording_test.json', { recorder: { output_objects: false } }, function(nockDone) {
+    http.get('http://google.com', function(res) {
+      res.once('end', function() {
+        nockDone();
+        fs.readFile(fixture, {encoding: 'utf8' }, function(err, data) {
+          if(!err) {
+            t.assert(false); // should not get here. output_objects: false does not save obj
+          }
+          t.end();
+        });
+      });
+      res.resume();
+    });
+  });
+  rimrafOnEnd(t);
+});
+
 test('teardown', function(t) {
   nockBack.setMode(originalMode);
   t.end();


### PR DESCRIPTION
Fixes this: https://github.com/node-nock/nock/issues/709

Up until ef870b7, the recorder was never able to take in options from `node.back`. The change has allowed the recorder to write JS code to JSON file.

This change will check `options` and see if the key `recorder.output_objects` exists, and if it does, it does not write output to disk.
