### PR TITLE
Fix isomorphic fetch usage with basicAuth/matchHeader

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -311,7 +311,7 @@ function matchStringOrRegexp(target, pattern) {
   if (pattern instanceof RegExp) {
     return target.toString().match(pattern);
   } else {
-    return target === pattern;
+    return target.toString() === pattern;
   }
 }
 

--- a/tests/test_isomorphic_fetch.js
+++ b/tests/test_isomorphic_fetch.js
@@ -32,7 +32,7 @@ test("string-based reqheaders match works", function(t) {
     get('/path2').
     reply(200, 'somemoardata');
 
-  fetch('http://isomorphicfetchland.com/path2', {
+  return fetch('http://isomorphicfetchland.com/path2', {
     headers: {
       'header': 'header value',
     }
@@ -46,6 +46,33 @@ test("string-based reqheaders match works", function(t) {
       t.end();
     }).
     catch(function(err) {
+      throw err;
+    });
+});
+
+test("basicAuth match works", function (t) {
+  var scope = nock('http://isomorphicfetchland.com').
+    get('/path2').
+    basicAuth({
+      user: 'username',
+      pass: 'password'
+    }).
+    reply(200, 'somemoardata');
+
+  return fetch('http://isomorphicfetchland.com/path2', {
+    headers: {
+      'Authorization': 'Basic ' + new Buffer('username:password').toString('base64'),
+    }
+  }).
+    then(function (res) {
+      return res.text();
+    }).
+    then(function (text) {
+      scope.done();
+      t.equal(text, 'somemoardata', "response should match");
+      t.end();
+    }).
+    catch(function (err) {
       throw err;
     });
 });

--- a/tests/test_isomorphic_fetch.js
+++ b/tests/test_isomorphic_fetch.js
@@ -76,3 +76,29 @@ test("basicAuth match works", function (t) {
       throw err;
     });
 });
+
+test("matchHeader works", function (t) {
+  var authorizationHeader = 'Basic ' + new Buffer('username:password').toString('base64');
+
+  var scope = nock('http://isomorphicfetchland.com').
+    get('/path2').
+    matchHeader('authorization', authorizationHeader).
+    reply(200, 'somemoardata');
+
+  return fetch('http://isomorphicfetchland.com/path2', {
+    headers: {
+      'Authorization': authorizationHeader,
+    }
+  }).
+    then(function (res) {
+      return res.text();
+    }).
+    then(function (text) {
+      scope.done();
+      t.equal(text, 'somemoardata', "response should match");
+      t.end();
+    }).
+    catch(function (err) {
+      throw err;
+    });
+});


### PR DESCRIPTION
This adds a `toString()` in `matchStringOrRegexp` to fix the usage of `matchHeader` and `basicAuth` together with isomorphic fetch.