### PR TITLE
Exclude test files from coverage reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,9 @@
     "reporter": [
       "lcov",
       "text-summary"
+    ],
+    "exclude": [
+      "tests/test_*.js"
     ]
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
   },
   "scripts": {
     "test": "tap --harmony ./tests/test_*.js",
-    "coverage": "nyc --reporter=lcov tap --harmony ./tests/test_*.js",
+    "coverage": "nyc tap --harmony ./tests/test_*.js",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "jshint": "jshint lib/*.js",
     "changelog": "changelog nock all -m > CHANGELOG.md",
@@ -212,5 +212,11 @@
     "jshint",
     "coverage"
   ],
+  "nyc": {
+    "reporter": [
+      "lcov",
+      "text-summary"
+    ]
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
Test files shouldn't be covered. This skews the coverage percentage and can lead to a decreasing coverage in pull requests because of uncovered test lines.