### PR TITLE
Fix interceptor if query have no query strings

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -256,8 +256,9 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
     var queryString;
     var queries;
 
-    if (this.queries && (queryIndex = path.indexOf('?')) !== -1) {
-        queryString = path.slice(queryIndex + 1);
+    if (this.queries) {
+        queryIndex = path.indexOf('?');
+        queryString = (queryIndex !== -1) ? path.slice(queryIndex + 1) : '';
         queries = qs.parse(queryString);
 
         // Only check for query string matches if this.queries is an object
@@ -299,7 +300,9 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
         }
 
         // Remove the query string from the path
-        path = path.substr(0, queryIndex);
+        if(queryIndex !== -1) {
+            path = path.substr(0, queryIndex);
+        }
     }
 
     if (typeof this.uri === 'function') {

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4772,6 +4772,24 @@ test('query() matches query values regardless of their type of declaration', fun
   })
 });
 
+test('query() doesn\'t match query values of requests without query string', function (t) {
+  var scope1 = nock('http://google.com')
+    .get('/')
+    .query({num:1,bool:true,empty:null,str:'fou'})
+    .reply(200, 'scope1');
+
+  var scope2 = nock('http://google.com')
+    .get('/')
+    .reply(200, 'scope2');
+
+  mikealRequest('http://google.com/', function(err, res) {
+    if (err) throw err;
+    t.equal(res.statusCode, 200);
+    t.equal(res.body, 'scope2');
+    t.end();
+  })
+});
+
 test('query() matches a query string using regexp', function (t) {
   var scope = nock('http://google.com')
     .get('/')


### PR DESCRIPTION
If an interceptor has query parameters, requests with no query string must not be intercepted.
Fixes #610 