### PR TITLE
fix for the "fix matchBody for multipart requests #425"

### DIFF
--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -29,7 +29,7 @@ function matchBody(spec, body) {
     return body.match(spec);
   }
 
-  if (typeof spec === "string") {
+  if (!isMultipart && typeof spec === "string") {
     spec = spec.replace(/\r?\n|\r/g, '');
   }
 

--- a/tests/test_body_match.js
+++ b/tests/test_body_match.js
@@ -66,3 +66,22 @@ test('match body with empty object inside', function (t) {
     t.end();
   });
 })
+
+test('match body with form multipart', function(t) {
+
+  nock('http://encodingsareus.com')
+    .post('/', "--fixboundary\r\nContent-Disposition: form-data; name=\"field\"\r\n\r\nvalue\r\n--fixboundary--\r\n")
+    .reply(200);
+
+  var r = mikealRequest({
+    url: 'http://encodingsareus.com/',
+    method: 'post',
+  }, function(err, res) {
+    if (err) throw err;
+    assert.equal(res.statusCode, 200);
+    t.end();
+  });
+  var form = r.form();
+  form._boundary = 'fixboundary';  // fix boundary so that request could match at all
+  form.append('field', 'value');
+});

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -30,9 +30,7 @@ tap.test('matchBody should not ignore new line characters from strings when Cont
       'Content-Type': "multipart/form-data;"
     }
   }
-  var matched = matchBody.call(testThis, function (body) {
-    return body === str1;
-  }, str2);
+  var matched = matchBody.call(testThis, str1, str2);
   t.true(matched);
   t.end()
 });
@@ -45,9 +43,7 @@ tap.test('matchBody should not ignore new line characters from strings when Cont
       'Content-Type': ["multipart/form-data;"]
     }
   }
-  var matched = matchBody.call(testThis, function (body) {
-    return body === str1;
-  }, str2);
+  var matched = matchBody.call(testThis, str1, str2);
   t.true(matched);
   t.end()
 });


### PR DESCRIPTION
This fix contains a fix for multipart handling as already merged in #425. The tests had an error where `str1` aka `spec` was never run through `match_body.js`.