### PR TITLE
Add tests/../browserify-bundle.js to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 node_modules
 .gitignore
 coverage
+tests/browserify-public/browserify-bundle.js


### PR DESCRIPTION
This saves us 1.2MB in the npm module. Solves the biggest reason why I raised #853.