### PR TITLE
Fix for "nock.cleanAll() does not remove pending mocks from scopes #856"

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -123,6 +123,11 @@ function remove(interceptor) {
 }
 
 function removeAll() {
+  Object.keys(allInterceptors).forEach(function(key) {
+    allInterceptors[key].scopes.forEach(function(interceptor) {
+      interceptor.scope.keyedInterceptors = {};
+    });
+  });
   allInterceptors = {};
 }
 

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2249,6 +2249,23 @@ test('clean all works', function(t) {
 
 });
 
+test('clean all should remove pending mocks from all scopes', function(t) {
+  var scope1 = nock('http://example.org')
+    .get('/somepath')
+    .reply(200, 'hey');
+  t.deepEqual(scope1.pendingMocks(), ['GET http://example.org:80/somepath']);
+  var scope2 = nock('http://example.com')
+    .get('/somepath')
+    .reply(200, 'hey');
+  t.deepEqual(scope2.pendingMocks(), ['GET http://example.com:80/somepath']);
+
+  nock.cleanAll();
+
+  t.deepEqual(scope1.pendingMocks(), []);
+  t.deepEqual(scope2.pendingMocks(), []);
+  t.end();
+});
+
 test('is done works', function(t) {
   var scope = nock('http://amazon.com')
     .get('/nonexistent')

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2249,7 +2249,7 @@ test('clean all works', function(t) {
 
 });
 
-test('clean all should remove pending mocks from all scopes', function(t) {
+test('cleanAll should remove pending mocks from all scopes', function(t) {
   var scope1 = nock('http://example.org')
     .get('/somepath')
     .reply(200, 'hey');


### PR DESCRIPTION
This fixes #856 . Currently, calling `nock.cleanAll()` will clean up and prevent any interception of the mocks but calling `pendingMocks()` on any of the scopes continues to return the mocked paths.
This has been fixed by updating the scopes of interceptors before cleaning them up.
```javascript
var scope = nock('http://example.org');
scope.get('/somepath').reply(200);

nock.cleanAll();

scope.pendingMocks(); // will now return []
```