### PR TITLE
Add some big folders to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
 node_modules
 .gitignore
 coverage
+.nyc_output
+tests


### PR DESCRIPTION
I was looking at my node_modules folder and wondering why it's so big (it's not nock, it's babel again :( ) and found two big folders in this project using the excellent baobab.

![screenshot from 2017-03-20 16 15 12](https://cloud.githubusercontent.com/assets/1611595/24109433/8640874c-0d88-11e7-9f52-5307ecedfbd7.png)

I thought I'd say hi and send a PR

So, hi! And here's a PR :heart: 