### PR TITLE
add hapijs boom support

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -58,6 +58,10 @@ Interceptor.prototype.replyWithError = function replyWithError(errorMessage) {
     return this.scope;
 };
 
+Interceptor.prototype.replyWithBoom = function({ output }) {
+  return this.reply(output.statusCode, output.payload, output.headers);
+};
+
 Interceptor.prototype.reply = function reply(statusCode, body, rawHeaders) {
     if (arguments.length <= 2 && _.isFunction(statusCode)) {
         body = statusCode;


### PR DESCRIPTION
Add [hapijs/boom](https://github.com/hapijs/boom) support

This PR allow you to mock a boom error:

**e.g:**
nock(SERVER_URL).post('/auth')
      .replyWithBoom(Boom.unauthorized('boom error message'));

Is equivalent to an hapi server that reply with Boom:
      .reply(Boom.unauthorized('boom error message'));
