### PR TITLE
Do not abort a an already aborted request, do not emit an error twice

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -167,6 +167,9 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
   };
 
   req.abort = function() {
+    if (aborted) {
+      return;
+    }
     debug('req.abort');
     aborted = true;
     if (!ended) {


### PR DESCRIPTION
Fixes #882

When a request is aborted, "nock" emits an "abort"-error.
If the client reacts on that error by aborting the request (this is what
"popsicle" does), the code will end in an endless loop.
This commit makes that the the "abort"-code is only executed, if the
request has not already been aborted.