### PR TITLE
Add an error code to NetConnectNotAllowedError

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -31,6 +31,7 @@ function NetConnectNotAllowedError(host, path) {
   Error.call(this);
 
   this.name    = 'NetConnectNotAllowedError';
+  this.code    = 'ENETUNREACH'
   this.message = 'Nock: Not allow net connect for "' + host + path + '"';
 
   Error.captureStackTrace(this, this.constructor);

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2833,12 +2833,13 @@ test('NetConnectNotAllowedError is instance of Error', function(t) {
   nock.enableNetConnect();
 });
 
-test('NetConnectNotAllowedError exposes the stack', function(t) {
+test('NetConnectNotAllowedError exposes the stack and has a code', function(t) {
   nock.disableNetConnect();
 
   http.get('http://www.amazon.com', function(res) {
     throw "should not request this";
   }).on('error', function (err) {
+    t.equal(err.code, 'ENETUNREACH')
     t.notEqual(err.stack, undefined);
     t.end();
   });


### PR DESCRIPTION
This is in line with [nodejs error codes](https://nodejs.org/api/all.html#errors_error_code
). I chose `ENETUNREACH` because it clearly defines the reason why the http request failed.

This helps testing when using an http request library that does retries as this isn't an error you would normally retry.