### PR TITLE
Changed Real HTTP request documentation to be more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,7 +987,7 @@ $ NOCK_OFF=true node my_test.js
 
 # Enable/Disable real HTTP request
 
-As default, if you do not mock a host, a real HTTP request will do, but sometimes you should not permit real HTTP request, so...
+By default, any requests made to a host that is not mocked will be executed normally. If you want to block these requests, nock allows you to do so. 
 
 For disabling real http requests.
 


### PR DESCRIPTION
I noticed that the opening line of the documentation regarding disabling real HTTP requests was a little difficult to follow. I hope this sounds a little better. 