### PR TITLE
Fix recording query strings, where value is an array

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -8,6 +8,7 @@ var debug = require('debug')('nock.recorder');
 var _ = require('lodash');
 var URL = require('url');
 var semver = require('semver')
+var qs = require('qs');
 
 var SEPARATOR = '\n<<<<<<-- cut here -->>>>>>\n';
 var recordingInProgress = false;
@@ -110,15 +111,12 @@ function generateRequestAndResponse(req, bodyChunks, options, res, dataChunks) {
   var queryIndex = 0;
   var queryObj = {};
   if ((queryIndex = req.path.indexOf('?')) !== -1) {
+    // Remove the query from the path
     path = path.substring(0, queryIndex);
 
     // Create the query() object
-    var queries = req.path.slice(queryIndex + 1).split('&');
-
-    for (var i = 0; i < queries.length; i++) {
-      var query = queries[i].split('=');
-      queryObj[query[0]] = query[1];
-    }
+    var queryStr = req.path.slice(queryIndex + 1);
+    queryObj = qs.parse(queryStr);
   }
 
   var ret = [];

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -810,6 +810,34 @@ test('outputs query string parameters using query()', {skip: process.env.AIRPLAN
   });
 });
 
+test('outputs query string arrays correctly', {skip: process.env.AIRPLANE}, function(t) {
+  nock.restore();
+  nock.recorder.clear();
+  t.equal(nock.recorder.play().length, 0);
+
+  nock.recorder.rec(true);
+
+  var makeRequest = function(callback) {
+    superagent
+      .get('https://example.com/')
+      .query({'foo':['bar', 'baz']})
+      .end(callback);
+  };
+
+  makeRequest(function(err, resp) {
+    t.ok(!err, err && err.message || 'no error');
+    t.ok(resp, 'have response');
+    t.ok(resp.headers, 'have headers');
+
+    var ret = nock.recorder.play();
+    t.equal(ret.length, 1);
+    t.type(ret[0], 'string');
+    var match = "\nnock('https://example.com:443', {\"encodedQueryParams\":true})\n  .get('/')\n  .query({\"foo\":[\"bar\",\"baz\"]})\n  .reply(";
+    t.equal(ret[0].substring(0, match.length), match);
+    t.end();
+  });
+});
+
 test('removes query params from from that path and puts them in query()', {skip: process.env.AIRPLANE}, function(t) {
   nock.restore();
   nock.recorder.clear();


### PR DESCRIPTION
This PR fixes an issue when using arrays inside a query string.

Prior to this change when using the following query string via superagent we get...
`.query({"foo":["bar","baz"]})`
The result is...
`.query({"foo":"baz"})`

Essentially the last value overrides any prior values due to the way the query string object is being formed. The fix is to simply use the `qs` library's `.parse` function which makes sense since the library is using `qs` elsewhere.

The result then becomes...
`.query({"foo":["bar","baz"]})`
Which now matches the superagent query input.

Resolves https://github.com/node-nock/nock/issues/896