### PR TITLE
fixing #533

### DIFF
--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -19,20 +19,6 @@ function matchBody(spec, body) {
 
   var isMultipart = contentType && contentType.toString().match(/multipart/);
 
-  //strip line endings from both so that we get a match no matter what OS we are running on
-  //if Content-Type does not contains 'multipart'
-  if (!isMultipart && typeof body === "string") {
-    body = body.replace(/\r?\n|\r/g, '');
-  }
-
-  if (spec instanceof RegExp) {
-    return body.match(spec);
-  }
-
-  if (!isMultipart && typeof spec === "string") {
-    spec = spec.replace(/\r?\n|\r/g, '');
-  }
-
   // try to transform body to json
   var json;
   if (typeof spec === 'object' || typeof spec === 'function') {
@@ -48,6 +34,20 @@ function matchBody(spec, body) {
 
   if (typeof spec === "function") {
     return spec.call(this, body);
+  }
+
+  //strip line endings from both so that we get a match no matter what OS we are running on
+  //if Content-Type does not contains 'multipart'
+  if (!isMultipart && typeof body === "string") {
+    body = body.replace(/\r?\n|\r/g, '');
+  }
+
+  if (spec instanceof RegExp) {
+    return body.match(spec);
+  }
+
+  if (!isMultipart && typeof spec === "string") {
+    spec = spec.replace(/\r?\n|\r/g, '');
   }
 
   return deepEqualExtended(spec, body);

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -12,6 +12,17 @@ tap.test('matchBody ignores new line characters from strings', function(t) {
   t.end()
 });
 
+tap.test('matchBody keeps new line characters if specs is a function', function(t) {
+  var body = "something //here is something more \n";
+  var bodyAsSpecParameter = null
+  var spec = function(bodyToTest) {
+    bodyAsSpecParameter = bodyToTest
+  }
+  matchBody(spec, body);
+  t.equal(bodyAsSpecParameter, body);
+  t.end()
+});
+
 tap.test('matchBody should not throw, when headers come node-fetch style as array', function(t) {
   var testThis = {
     headers: {


### PR DESCRIPTION
**Problem:**
If the matcher for the body is a function the new lines in the body should not be stripped.
Because the developer writing the test should know that there are newline in the body.

Also there are API which expect newlines in the body, with the stripping it's hard to write tests for these APIs.

**Solution:**

I just change the order within match_body.js. This way a function `spec` will be used first and only if the spec is not a function the body will be altered and the new lines will be removed.

**Changes:**

- One new test case added
- Code order in match_body changed

closes #533