### PR TITLE
pinning node to version 7.9, because of problems with zombie on 7.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - 4
   - 6
-  - 7
+  - 7.9
 script: "npm run coverage && npm run integration"
 sudo: false
 after_success: "npm run coveralls"


### PR DESCRIPTION
See #933 

I've no idea how to fix the problem with zombie and the commit history on master for zombie shows many failing build, therefore i propose to pin the node version for now to keep the builds passing.

This can be reverted when a proper solution can be found for the failing browserify tests with zombie.