### PR TITLE
Skip browserify test because zombie fails @7.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     "restify": "^4.0.4",
     "restler": "3.4.0",
     "rimraf": "^2.3.2",
+    "semver": "^5.3.0",
     "superagent": "^3.5.0",
     "tap": "^10.0.0",
     "zombie": "^5.0.1"

--- a/tests/test_browserify.js
+++ b/tests/test_browserify.js
@@ -1,12 +1,14 @@
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var http = require('http');
-var browserify = require('browserify');
-var Static = require('node-static');
-var Browser = require('zombie');
+var semver = require('semver');
+if (semver.gt(process.versions.node, '7.9.0')) return
 
+var Browser = require('zombie');
+var Static = require('node-static');
+var browserify = require('browserify');
+var fs = require('fs');
+var http = require('http');
+var path = require('path');
 var test = require('tap').test;
 var before = test;
 var after  = test;
@@ -40,7 +42,7 @@ test('run bundle', function(t) {
   var browser = new Browser();
 
   browser.on('error', function(err) {
-    console.error('BROWSER ERROR: ' + err.stack);
+    throw err
   });
 
   browser.visit('/', function() {


### PR DESCRIPTION
Skipping the browserify test for Node versions >7.9 to remedy #933, assuming this might be a [Zombie](https://github.com/assaf/zombie) issue, which is out of scope for me to fix.