### PR TITLE
Fix for #947

### DIFF
--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -145,7 +145,7 @@ tap.test('nockBack dryrun tests', function (nw) {
 
     nockBack(fixture, function (done) {
       var req = http.request({
-          host: "www.amazon.com"
+          host: "amazon.com"
         , path: '/'
         , port: 80
         }, function(res) {


### PR DESCRIPTION
The failing test was checking that a call to `www.amazon.com` was returning data. This URL does not return any data any longer - changed it to one that does.