### PR TITLE
Improve Match Logging

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -318,10 +318,11 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
 
     // special logger for query()
     if (queryIndex !== -1) {
-        this.scope.logger('matching ' + matchKey + '?' + queryString + ' to ' + this._key +
-        ' with query(' + stringify(this.queries) + '): ' + matches);
+        this.scope.logger('matching ' + method + ' ' + matchKey + path + '?' + queryString 
+        + ' to ' + this._key + ' with query(' + stringify(this.queries) + '): ' + matches);
     } else {
-        this.scope.logger('matching ' + matchKey + ' to ' + this._key + ': ' + matches);
+        this.scope.logger('matching ' + method + ' ' + matchKey + path 
+        + ' to ' + this._key + ': ' + matches);
     }
 
     if (matches) {


### PR DESCRIPTION
Currently, matching logging does not include the method or path of the request.  I have added these to make debugging non-matches easier.