### PR TITLE
fix: logging recorded requests resulted in output of [Object Object]

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -282,7 +282,7 @@ function record(rec_options) {
 
         if (!dont_print) {
           if (use_separator) {
-            logging(SEPARATOR + out + SEPARATOR);
+            logging(SEPARATOR + JSON.stringify(out, null, 2) + SEPARATOR);
           } else {
             logging(out);
           }


### PR DESCRIPTION
## observed behavior

Capturing and printing recorded results, using:

```js
nock.recorder.rec({
  output_objects: true
});
```
resulted in `[Object Object]` being output to standard out.

## Expected Behavior

A serialized JSON object would be output.