### PR TITLE
`nock.define()` ignores badheaders option

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -297,6 +297,7 @@ function define(nockDefs) {
       , status     = getStatusFromDefinition(nockDef)
       , rawHeaders = nockDef.rawHeaders || []
       , reqheaders = nockDef.reqheaders || {}
+      , badheaders = nockDef.badheaders || []
       , body       = nockDef.body       || ''
       , options    = nockDef.options    || {};
 
@@ -305,6 +306,7 @@ function define(nockDefs) {
     //  be changing the user's options object so we clone it first.
     options = _.clone(options) || {};
     options.reqheaders = reqheaders;
+    options.badheaders = badheaders;
 
     //  Response is not always JSON as it could be a string or binary data or
     //  even an array of binary buffers (e.g. when content is enconded)

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -3640,6 +3640,47 @@ test('define() uses reqheaders', function(t) {
 
 });
 
+test('define() uses badheaders', function(t) {
+  var nockDef = [{
+    "scope":"http://example.com",
+    "method":"GET",
+    "path":"/",
+    "status":401,
+    "badheaders": ['x-foo']
+  }, {
+    "scope":"http://example.com",
+    "method":"GET",
+    "path":"/",
+    "status":200,
+    "reqheaders": {
+      'x-foo': 'bar'
+    }
+  }];
+
+  var nocks = nock.define(nockDef);
+
+  t.ok(nocks);
+
+  var req = new http.request({
+    host: 'example.com',
+    method: 'GET',
+    path: '/',
+    headers: {
+      'x-foo': 'bar'
+    }
+  }, function(res) {
+    t.equal(res.statusCode, 200);
+
+    res.once('end', function() {
+      t.end();
+    });
+    // Streams start in 'paused' mode and must be started.
+    // See https://nodejs.org/api/stream.html#stream_class_stream_readable
+    res.resume();
+  });
+  req.end();
+});
+
 test('sending binary and receiving JSON should work ', function(t) {
   var scope = nock('http://example.com')
     .filteringRequestBody(/.*/, '*')


### PR DESCRIPTION
closes #961