### PR TITLE
compare falsy header values & numbers correctly

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -320,9 +320,9 @@ function percentEncode(str) {
 }
 
 function matchStringOrRegexp(target, pattern) {
-  var str = target && target.toString ? target.toString() : target;
+  var str = !_.isUndefined(target) && target.toString ? target.toString() : target;
 
-  return pattern instanceof RegExp  ? str.match(pattern) : str === pattern;
+  return pattern instanceof RegExp  ? str.match(pattern) : str === String(pattern);
 }
 
 // return [newKey, newValue]

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -146,9 +146,11 @@ tap.test('deleteHeadersField deletes fields with case-insensitive field names', 
 
 });
 
-tap.test('matchStringOrRegexp', function (t) {
+tap.test('matchStringOrRegexp', {only: true}, function (t) {
   t.true(common.matchStringOrRegexp('to match', 'to match'), 'true if pattern is string and target matches');
   t.false(common.matchStringOrRegexp('to match', 'not to match'), 'false if pattern is string and target doesn\'t match');
+
+  t.true(common.matchStringOrRegexp(123, 123), 'true if pattern is number and target matches');
 
   t.ok(common.matchStringOrRegexp('to match', /match/), 'match if pattern is regex and target matches');
   t.false(common.matchStringOrRegexp('to match', /not/), 'false if pattern is regex and target doesn\'t match');


### PR DESCRIPTION
The "mocking succeeds when mocked and specified request headers have falsy values" which I made for #966 was still failing when run with `{only: true}` :/ I really don’t trust the tests much right now

Anyway, this fixes it for good now, I hope