### PR TITLE
Fix #992 Bind the socket event listener to the request object

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -192,7 +192,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
   req.once = req.on = function(event, listener) {
     // emit a fake socket.
     if (event == 'socket') {
-      listener(req.socket);
+      listener.call(req, req.socket);
       req.socket.emit('connect', req.socket);
       req.socket.emit('secureConnect', req.socket);
     }

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4225,6 +4225,7 @@ test('request emits socket', function(t) {
 
   var req = http.get('http://gotzsocketz.com');
   req.once('socket', function(socket) {
+    t.equal(this, req);
     t.type(socket, Object);
     t.type(socket.getPeerCertificate(), 'string');
     t.end();

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -3567,35 +3567,37 @@ test('define() works with binary buffers', function(t) {
 
 });
 
-test('issue #163 - Authorization header isn\'t mocked', function(t) {
-  nock.enableNetConnect();
-  function makeRequest(cb) {
-    var r = http.request(
-      {
-        hostname: 'www.example.com',
-        path: '/',
-        method: 'GET',
-        auth: 'foo:bar'
-      },
-      function(res) {
-        cb(res.req._headers);
-      }
-    );
-    r.end();
-  }
+if (process.versions.node >= '0.11' ) {
+  test('issue #163 - Authorization header isn\'t mocked', function(t) {
+    nock.enableNetConnect();
+    function makeRequest(cb) {
+      var r = http.request(
+        {
+          hostname: 'www.example.com',
+          path: '/',
+          method: 'GET',
+          auth: 'foo:bar'
+        },
+        function(res) {
+          cb(res.req._headers);
+        }
+      );
+      r.end();
+    }
 
-  makeRequest(function(headers) {
-    var n = nock('http://www.example.com', {
-      reqheaders: { 'authorization': 'Basic Zm9vOmJhcg==' }
-    }).get('/').reply(200);
+    makeRequest(function(headers) {
+      var n = nock('http://www.example.com', {
+        reqheaders: { 'authorization': 'Basic Zm9vOmJhcg==' }
+      }).get('/').reply(200);
 
-    makeRequest(function(nockHeader) {
-      n.done();
-      t.equivalent(headers, nockHeader);
-      t.end();
+      makeRequest(function(nockHeader) {
+        n.done();
+        t.equivalent(headers, nockHeader);
+        t.end();
+      });
     });
   });
-});
+}
 
 test('define() uses reqheaders', function(t) {
   var nockDef = {


### PR DESCRIPTION
Backport of https://github.com/node-nock/nock/commit/50859e52fd86759f3215cdc3509c83d364b84cf5 from 9.0.x to 8.2.x. Fixes compatibility with Axios. Fixes #992. 