### PR TITLE
Include `path` in the matching log output

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -316,10 +316,10 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
 
     // special logger for query()
     if (queryIndex !== -1) {
-        this.scope.logger('matching ' + matchKey + '?' + queryString + ' to ' + this._key +
+        this.scope.logger('matching ' + matchKey + path + '?' + queryString + ' to ' + this._key +
             ' with query(' + stringify(this.queries) + '): ' + matches);
     } else {
-        this.scope.logger('matching ' + matchKey + ' to ' + this._key + ': ' + matches);
+        this.scope.logger('matching ' + matchKey + path + ' to ' + this._key + ': ' + matches);
     }
 
     if (matches) {


### PR DESCRIPTION
closes #989

i didn't find any tests around log output, so i simply updated the log output. both changes are needed, one for when query params are defined, the other when no query is defined. i verified manually that each fix handles the appropriate case properly after the change.