### PR TITLE
Fix matchStringOrRegexp TypeError

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -320,7 +320,7 @@ function percentEncode(str) {
 }
 
 function matchStringOrRegexp(target, pattern) {
-  var str = !_.isUndefined(target) ? (target.toString ? target.toString() : target) : '';
+  var str = (!_.isUndefined(target) && target.toString && target.toString()) || '';
 
   return pattern instanceof RegExp  ? str.match(pattern) : str === String(pattern);
 }

--- a/lib/common.js
+++ b/lib/common.js
@@ -320,7 +320,7 @@ function percentEncode(str) {
 }
 
 function matchStringOrRegexp(target, pattern) {
-  var str = !_.isUndefined(target) && target.toString ? target.toString() : target;
+  var str = !_.isUndefined(target) ? (target.toString ? target.toString() : target) : '';
 
   return pattern instanceof RegExp  ? str.match(pattern) : str === String(pattern);
 }

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -152,6 +152,9 @@ tap.test('matchStringOrRegexp', {only: true}, function (t) {
 
   t.true(common.matchStringOrRegexp(123, 123), 'true if pattern is number and target matches');
 
+  t.false(common.matchStringOrRegexp(undefined, 'to not match'), 'handle undefined target when pattern is string');
+  t.false(common.matchStringOrRegexp(undefined, /not/), 'handle undefined target when pattern is regex');
+
   t.ok(common.matchStringOrRegexp('to match', /match/), 'match if pattern is regex and target matches');
   t.false(common.matchStringOrRegexp('to match', /not/), 'false if pattern is regex and target doesn\'t match');
   t.end();


### PR DESCRIPTION
Fixes `TypeError: Cannot read property 'match' of undefined` when `pattern` is a regex and `target` is undefined.