### PR TITLE
Fix body.exec is not a function

### DIFF
--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -43,7 +43,11 @@ function matchBody(spec, body) {
   }
 
   if (spec instanceof RegExp) {
-    return body.match(spec);
+    if (typeof body === "string") {
+      return body.match(spec);
+    } else {
+      return qs.stringify(body).match(spec);
+    }
   }
 
   if (!isMultipart && typeof spec === "string") {

--- a/tests/test_body_match.js
+++ b/tests/test_body_match.js
@@ -5,6 +5,27 @@ var test = require('tap').test;
 var mikealRequest = require('request');
 var assert = require('assert');
 
+test('match body is regex trying to match string', function (t) {
+
+  nock('http://encodingsareus.com')
+    .post('/', new RegExp("a.+"))
+    .reply(200);
+
+  mikealRequest({
+    url: 'http://encodingsareus.com/',
+    method: 'post',
+    json: {
+      auth: {
+        passwd: 'abc'
+      }
+    },
+  }, function(err, res) {
+    if (err) throw err;
+    assert.equal(res.statusCode, 200);
+    t.end();
+  });
+
+});
 test('match body with regex', function (t) {
 
   nock('http://encodingsareus.com')


### PR DESCRIPTION
Re-add support for matching body to query string regex

Fixes #1005 and #1004 

This was working before the recent change to body parser. 

From the docs:

```
The request body can be a string, a RegExp, a JSON object or a function.
var scope = nock('http://myapp.iriscouch.com')
                .post('/users', /email=.?@gmail.com/gi)
                .reply(201, {
                  ok: true,
                  id: '123ABC',
                  rev: '946B7D1C'
                });
```
