### PR TITLE
Bug 976 allowunmocked https query

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -391,7 +391,18 @@ function activate() {
       //    our own OverriddenClientRequest.
       req = new http.ClientRequest(options);
 
-      res = RequestOverrider(req, options, interceptors, remove);
+      res = RequestOverrider(req, options, interceptors, remove, function() {}, function(options, callback){
+        var req;
+        if (options.protocol === 'https') {
+          var ClientRequest = http.ClientRequest;
+          http.ClientRequest = originalClientRequest;
+          req = overriddenRequest(options, callback);
+          http.ClientRequest = ClientRequest;
+        } else {
+          req = overriddenRequest(options, callback);
+        }
+        return req
+      });
       if (callback) {
         res.on('response', callback);
       }

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -355,7 +355,7 @@ function activate() {
     var req,
         res;
 
-    function fallbackRequest(options, callback) {
+    function fallbackClientRequest(options, callback) {
       var req;
       if (options.protocol === 'https') {
         var ClientRequest = http.ClientRequest;
@@ -388,7 +388,7 @@ function activate() {
       });
 
       if (! matches && allowUnmocked) {
-        req = fallbackRequest(options, callback);
+        req = fallbackClientRequest(options, callback);
         globalEmitter.emit('no match', req);
         return req;
       }
@@ -397,7 +397,7 @@ function activate() {
       //    our own OverriddenClientRequest.
       req = new http.ClientRequest(options);
 
-      res = RequestOverrider(req, options, interceptors, remove, function() {}, fallbackRequest);
+      res = RequestOverrider(req, options, interceptors, remove, function() {}, fallbackClientRequest);
       if (callback) {
         res.on('response', callback);
       }

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -355,6 +355,19 @@ function activate() {
     var req,
         res;
 
+    function fallbackRequest(options, callback) {
+      var req;
+      if (options.protocol === 'https') {
+        var ClientRequest = http.ClientRequest;
+        http.ClientRequest = originalClientRequest;
+        req = overriddenRequest(options, callback);
+        http.ClientRequest = ClientRequest;
+      } else {
+        req = overriddenRequest(options, callback);
+      }
+      return req
+    }
+
     if (typeof options === 'string') {
       options = parse(options);
     }
@@ -375,14 +388,7 @@ function activate() {
       });
 
       if (! matches && allowUnmocked) {
-        if (proto === 'https') {
-          var ClientRequest = http.ClientRequest;
-          http.ClientRequest = originalClientRequest;
-          req = overriddenRequest(options, callback);
-          http.ClientRequest = ClientRequest;
-        } else {
-          req = overriddenRequest(options, callback);
-        }
+        req = fallbackRequest(options, callback);
         globalEmitter.emit('no match', req);
         return req;
       }
@@ -391,18 +397,7 @@ function activate() {
       //    our own OverriddenClientRequest.
       req = new http.ClientRequest(options);
 
-      res = RequestOverrider(req, options, interceptors, remove, function() {}, function(options, callback){
-        var req;
-        if (options.protocol === 'https') {
-          var ClientRequest = http.ClientRequest;
-          http.ClientRequest = originalClientRequest;
-          req = overriddenRequest(options, callback);
-          http.ClientRequest = ClientRequest;
-        } else {
-          req = overriddenRequest(options, callback);
-        }
-        return req
-      });
+      res = RequestOverrider(req, options, interceptors, remove, function() {}, fallbackRequest);
       if (callback) {
         res.on('response', callback);
       }

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -360,11 +360,11 @@ function activate() {
     }
     options.proto = proto;
 
-    var interceptors = interceptorsFor(options)
+    var interceptors = interceptorsFor(options);
 
     if (isOn() && interceptors) {
-      var matches = false,
-          allowUnmocked = false;
+      var matches,
+          allowUnmocked;
 
       matches = !! _.find(interceptors, function(interceptor) {
         return interceptor.matchIndependentOfBody(options);

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -78,7 +78,7 @@ function setRequestHeaders(req, options, interceptor) {
 
 }
 
-function RequestOverrider(req, options, interceptors, remove, cb) {
+function RequestOverrider(req, options, interceptors, remove, cb, fallbackRequest) {
   var response;
   if (IncomingMessage) {
     response = new IncomingMessage(new EventEmitter());
@@ -245,7 +245,12 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       });
       if (interceptor && req instanceof ClientRequest) {
         if (interceptor.options.allowUnmocked) {
-          var newReq = new ClientRequest(options, cb);
+          var newReq;
+          if (fallbackRequest) {
+            newReq = fallbackRequest(options, cb)
+          } else {
+            newReq = new ClientRequest(options, cb);
+          }
           propagate(newReq, req);
           //  We send the raw buffer as we received it, not as we interpreted it.
           newReq.end(requestBodyBuffer);

--- a/tests/test_https_allowunmocked.js
+++ b/tests/test_https_allowunmocked.js
@@ -22,3 +22,24 @@ test('allowUnmocked for https', {skip: process.env.AIRPLANE}, function(t) {
     t.end();
   });
 });
+
+test('allowUnmocked for https with query test miss', {skip: process.env.AIRPLANE}, function(t) {
+  var nock = require('../');
+  nock.enableNetConnect();
+  nock('https://www.google.com', {allowUnmocked: true})
+  .get('/search')
+  .query(function() {return false;})
+  .reply(500);
+
+  var options = {
+    method: 'GET',
+    uri: 'https://www.google.com/search'
+  };
+
+  mikealRequest(options, function(err, resp, body) {
+    t.notOk(err, 'should be no error');
+    t.true(typeof body !== 'undefined', 'body should not be undefined');
+    t.true(body.length !== 0, 'body should not be empty');
+    t.end();
+  });
+});


### PR DESCRIPTION
This is a response to:
https://github.com/node-nock/nock/issues/976#issuecomment-331352387 

It adds a test which the current mainline branch fails, which takes an https host which is a path match but a query miss -- and which is coerced to http by the mainline interpretation. I added it to the test_https_allowunmocked.js file, where it seems like it belongs, but I'm not wedded to that. I also did as much as possible to copy the test that's currently there.

To pass this test, it adds an optional final argument `fallbackRequest` to `RequestOverrider`, which, if present, supersedes `http.ClientRequest` in the case where a request is passed through. I'm not excited to change the interface, but the only way I see around that is to read the body buffer and query strings twice, in order to use `Interceptor.match` instead of `Interceptor.matchIndependentOfBody` in intercept.js line 373. I could probably do this (and someone who knows nock better definitely could), but it's a more invasive refactor. 

Since the function I'm passing into `fallbackRequest` was basically a copy and paste of the same logic being used in the overriden request, I moved it into a local function. 

I also changed lines 363, 366, and 367 in intercept.js for style/clarity reasons, but as far as I can tell, these changes don't affect the code and I'll happily leave them if the old version is more inline with nock's house style. 