### PR TITLE
Added support for regex with query params

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -339,7 +339,10 @@ Interceptor.prototype.matchIndependentOfBody = function matchIndependentOfBody(o
         , path = options.path
         , proto = options.proto;
 
-    path = path.split('?')[0];
+    // NOTE: Do not split off the query params as the regex could use them
+    if (!isRegex) {
+        path = path.split('?')[0];
+    }
 
     if (this.scope.transformPathFunction) {
         path = this.scope.transformPathFunction(path);

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -5126,6 +5126,24 @@ test('match multiple paths to domain using regexp with allowUnmocked (#835)', fu
   });
 });
 
+test('match domain and path using regexp with query params and allow unmocked', function(t) {
+  nock.cleanAll();
+  var imgResponse = 'Matched Images Page';
+  var opts = { allowUnmocked: true };
+
+  var scope = nock(/google/, opts)
+    .get(/imghp\?hl=en/)
+    .reply(200, imgResponse);
+
+  mikealRequest.get('http://www.google.com/imghp?hl=en', function (err, res, body) {
+    scope.done();
+    t.type(err, 'null');
+    t.equal(res.statusCode, 200);
+    t.equal(body, imgResponse);
+    t.end();
+  });
+});
+
 test('multiple interceptors override headers from unrelated request', function (t) {
   nock.cleanAll();
 


### PR DESCRIPTION
Followup to https://github.com/node-nock/nock/pull/973

Failing test in commit 1

A combination of a regex that is reliant on query params + allow unmocked would fail. Fix is in commit 2 https://github.com/node-nock/nock/pull/1010/commits/424f0eda1790c98e3b1105988e633c27b9e40294