### PR TITLE
Fixed issue with record -> replay body encoding

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -72,7 +72,7 @@ var getBodyFromChunks = function(chunks, headers) {
   //    2.  A string buffer which represents a JSON object.
   //    3.  A string buffer which doesn't represent a JSON object.
 
-  if(common.isBinaryBuffer(mergedBuffer)) {
+  if(common.isContentEncoded(headers) && common.isBinaryBuffer(mergedBuffer)) {
     return mergedBuffer.toString('hex');
   } else {
     var maybeStringifiedJson = mergedBuffer.toString('utf8');


### PR DESCRIPTION
This matches the replay decode check in https://github.com/node-nock/nock/blob/master/lib/request_overrider.js#L325

Ideally we would also add a corresponding check for isBinaryRequestBodyBuffer (https://github.com/node-nock/nock/blob/master/lib/request_overrider.js#L347):
> if((common.isContentEncoded(headers) || isBinaryRequestBodyBuffer) && common.isBinaryBuffer(mergedBuffer)) { ...

However I wanted to keep this pr small and get some feedback.