### PR TITLE
fix regexp on nested json object

### DIFF
--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var deepEqual = require('deep-equal');
-var qs = require('querystring');
+var qs = require('qs');
 
 module.exports =
 function matchBody(spec, body) {

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "lodash": "~4.17.2",
     "mkdirp": "^0.5.0",
     "propagate": "0.4.0",
-    "qs": "^6.0.2",
+    "qs": "^6.5.1",
     "semver": "^5.3.0"
   },
   "devDependencies": {

--- a/tests/test_body_match.js
+++ b/tests/test_body_match.js
@@ -88,6 +88,27 @@ test('match body with empty object inside', function (t) {
   });
 })
 
+test('match body with nested object inside', function (t) {
+
+  nock('http://encodingsareus.com')
+    .post('/', /x/)
+    .reply(200);
+
+  mikealRequest({
+    url: 'http://encodingsareus.com/',
+    method: 'post',
+    json: {
+      obj: {
+        x: 1
+      },
+    },
+  }, function(err, res) {
+    if (err) throw err;
+    assert.equal(res.statusCode, 200);
+    t.end();
+  });
+})
+
 test('doesn\'t match body with mismatching keys', function (t) {
   nock('http://encodingsareus.com')
     .post('/', { a: 'a' })


### PR DESCRIPTION
The querystring package does not stringify nested attributes of json object.
It'll broken regexp matching if request body contains complex json data.
```
> qs = require('querystring')
> qs.stringify({ a: { b: 1 } })
'a='
```