### PR TITLE
Bug 976 expected https protocol

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -238,6 +238,9 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     /// like to change request.path in mid-flight.
     options.path = req.path;
 
+    // fixes #976
+    options.protocol = options.proto + ':';
+
     interceptors.forEach(function(interceptor) {
       //  For correct matching we need to have correct request headers - if these were specified.
       setRequestHeaders(req, options, interceptor);

--- a/tests/test_https_allowunmocked.js
+++ b/tests/test_https_allowunmocked.js
@@ -22,3 +22,24 @@ test('allowUnmocked for https', {skip: process.env.AIRPLANE}, function(t) {
     t.end();
   });
 });
+
+test('allowUnmocked for https with query test miss', {skip: process.env.AIRPLANE}, function(t) {
+  var nock = require('../');
+  nock.enableNetConnect();
+  nock('https://www.google.com', {allowUnmocked: true})
+  .get('/search')
+  .query(function() {return false;})
+  .reply(500);
+
+  var options = {
+    method: 'GET',
+    uri: 'https://www.google.com/search'
+  };
+
+  mikealRequest(options, function(err, resp, body) {
+    t.notOk(err, 'should be no error');
+    t.true(typeof body !== 'undefined', 'body should not be undefined');
+    t.true(body.length !== 0, 'body should not be empty');
+    t.end();
+  });
+});

--- a/tests/test_https_allowunmocked.js
+++ b/tests/test_https_allowunmocked.js
@@ -2,10 +2,11 @@
 
 var test          = require('tap').test;
 var mikealRequest = require('request');
+var nock          = require('../');
+
+nock.enableNetConnect();
 
 test('allowUnmocked for https', {skip: process.env.AIRPLANE}, function(t) {
-  var nock = require('../');
-  nock.enableNetConnect();
   nock('https://www.google.com/', {allowUnmocked: true})
   .get('/pathneverhit')
   .reply(200, {foo: 'bar'});
@@ -24,12 +25,11 @@ test('allowUnmocked for https', {skip: process.env.AIRPLANE}, function(t) {
 });
 
 test('allowUnmocked for https with query test miss', {skip: process.env.AIRPLANE}, function(t) {
-  var nock = require('../');
-  nock.enableNetConnect();
+  nock.cleanAll();
   nock('https://www.google.com', {allowUnmocked: true})
-  .get('/search')
-  .query(function() {return false;})
-  .reply(500);
+    .get('/search')
+    .query(function() {return false;})
+    .reply(500);
 
   var options = {
     method: 'GET',


### PR DESCRIPTION
We must pass protocol [option](https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_http_request_options_callback) to the [ClientRequest constructor ](https://github.com/node-nock/nock/blob/master/lib/request_overrider.js#L258). By default, it uses `http:` [protocol](https://github.com/nodejs/node/blob/master/lib/_http_client.js#L112) but when we do https request our agent has `https:` protocol. If the protocol does not equal expected then the [error is thrown](https://github.com/nodejs/node/blob/master/lib/_http_client.js#L131)