### PR TITLE
fix: URLs Ending with Comma Cause "No match for HTTP request" Error (#1018)

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -266,7 +266,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
         }
       }
 
-      var err = new Error("Nock: No match for request " + common.stringifyRequest(options, requestBody));
+      var err = new Error('Nock: No match for request ' + common.stringifyRequest(options, requestBody) + ' Got instead ' + common.stringifyRequest(options));
       err.statusCode = err.status = 404;
       emitError(err);
       return;

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1874,7 +1874,10 @@ test("emits error if https route is missing", function(t) {
   // This listener is intentionally after the end call so make sure that
   // listeners added after the end will catch the error
   req.on('error', function (err) {
-    t.equal(err.message.trim(), 'Nock: No match for request ' + JSON.stringify({"method":"GET","url":"https://google.com/abcdef892932"}, null, 2));
+    var headerOptions = JSON.stringify({"method":"GET","url":"https://google.com/abcdef892932"}, null, 2);
+    var expectedError = 'Nock: No match for request ' + headerOptions + ' Got instead ' + headerOptions
+
+    t.equal(err.message.trim(), expectedError);
     t.end();
   });
 });
@@ -1897,7 +1900,10 @@ test("emits error if https route is missing", function(t) {
   // This listener is intentionally after the end call so make sure that
   // listeners added after the end will catch the error
   req.on('error', function (err) {
-    t.equal(err.message.trim(), 'Nock: No match for request ' + JSON.stringify({"method":"GET","url":"https://google.com:123/dsadsads"}, null, 2));
+    var headerOptions = JSON.stringify({"method":"GET","url":"https://google.com:123/dsadsads"}, null, 2);
+    var expectedError = 'Nock: No match for request ' + headerOptions + ' Got instead ' + headerOptions
+
+    t.equal(err.message.trim(), expectedError);
     t.end();
   });
 });
@@ -4656,7 +4662,10 @@ test('you must setup an interceptor for each request', function(t) {
     t.equal(body, 'First match', 'should match first request response body');
 
     mikealRequest.get('http://www.example.com/hey', function(error, res, body) {
-      t.equal(error && error.toString(), 'Error: Nock: No match for request ' + JSON.stringify({"method":"GET","url":"http://www.example.com/hey","headers":{"host":"www.example.com"}}, null, 2));
+      var headerOptions = JSON.stringify({"method":"GET","url":"http://www.example.com/hey","headers":{"host":"www.example.com"}}, null, 2);
+      var expectedError = 'Error: Nock: No match for request ' + headerOptions + ' Got instead ' + headerOptions
+
+      t.equal(error && error.toString(), expectedError);
       scope.done();
       t.end();
     });
@@ -4997,7 +5006,10 @@ test('query() with a function, function return false the query treat as Un-match
     .reply(200);
 
   mikealRequest('http://google.com/?i=should&pass=?', function(err, res) {
-    t.equal(err.message.trim(), 'Nock: No match for request ' + JSON.stringify({"method":"GET","url":"http://google.com/?i=should&pass=?","headers":{"host":"google.com"}}, null, 2));
+    var headerOptions = JSON.stringify({"method":"GET","url":"http://google.com/?i=should&pass=?","headers":{"host":"google.com"}}, null, 2);
+    var expectedError = 'Nock: No match for request ' + headerOptions + ' Got instead ' + headerOptions
+
+    t.equal(err.message.trim(), expectedError);
     t.end();
   })
 });
@@ -5009,7 +5021,10 @@ test('query() will not match when a query string does not match name=value', fun
     .reply(200);
 
   mikealRequest('https://c.com/b?foo=baz', function(err, res) {
-    t.equal(err.message.trim(), 'Nock: No match for request ' + JSON.stringify({"method":"GET","url":"https://c.com/b?foo=baz","headers":{"host":"c.com"}}, null, 2));
+    var headerOptions = JSON.stringify({"method":"GET","url":"https://c.com/b?foo=baz","headers":{"host":"c.com"}}, null, 2);
+    var expectedError = 'Nock: No match for request ' + headerOptions + ' Got instead ' + headerOptions
+
+    t.equal(err.message.trim(), expectedError);
     t.end();
   })
 });
@@ -5021,7 +5036,10 @@ test('query() will not match when a query string is present that was not registe
     .reply(200);
 
   mikealRequest('https://b.com/c?foo=bar&baz=foz', function(err, res) {
-    t.equal(err.message.trim(), 'Nock: No match for request ' + JSON.stringify({"method":"GET","url":"https://b.com/c?foo=bar&baz=foz","headers":{"host":"b.com"}}, null, 2));
+    var headerOptions = JSON.stringify({"method":"GET","url":"https://b.com/c?foo=bar&baz=foz","headers":{"host":"b.com"}}, null, 2);
+    var expectedError = 'Nock: No match for request ' + headerOptions + ' Got instead ' + headerOptions
+
+    t.equal(err.message.trim(), expectedError);
     t.end();
   })
 });
@@ -5033,7 +5051,10 @@ test('query() will not match when a query string is malformed', function (t) {
     .reply(200);
 
   mikealRequest('https://a.com/d?foobar', function(err, res) {
-    t.equal(err.message.trim(), 'Nock: No match for request ' + JSON.stringify({"method":"GET","url":"https://a.com/d?foobar","headers":{"host":"a.com"}}, null, 2));
+    var headerOptions = JSON.stringify({"method":"GET","url":"https://a.com/d?foobar","headers":{"host":"a.com"}}, null, 2);
+    var expectedError = 'Nock: No match for request ' + headerOptions + ' Got instead ' + headerOptions
+
+    t.equal(err.message.trim(), expectedError);
     t.end();
   })
 });
@@ -5050,7 +5071,10 @@ test('query() will not match when a query string has fewer correct values than e
     .reply(200);
 
   mikealRequest('http://google.com/?num=1str=fou', function(err, res) {
-    t.equal(err.message.trim(), 'Nock: No match for request ' + JSON.stringify({"method":"GET","url":"http://google.com/?num=1str=fou","headers":{"host":"google.com"}}, null, 2));
+    var headerOptions = JSON.stringify({"method":"GET","url":"http://google.com/?num=1str=fou","headers":{"host":"google.com"}}, null, 2);
+    var expectedError = 'Nock: No match for request ' + headerOptions + ' Got instead ' + headerOptions
+
+    t.equal(err.message.trim(), expectedError);
     t.end();
   })
 });


### PR DESCRIPTION
Slight change to the error message thrown comparing the header received with the header expected. The idea is that hopefully, it will help identify more quickly what exactly went wrong. The new error message will look something like this:

`Nock: No match for request {"method":"GET","url":"http://google.com/?num=1str=fou"} Got instead {"method":"GET","url":"http://google.com/?num=1str=fou@#"}`

closes #1018