### PR TITLE
Implement callback on req.write and req.end

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -127,15 +127,20 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
 
   req.socket = response.socket = Socket({ proto: options.proto });
 
-  req.write = function(buffer, encoding) {
+  req.write = function(buffer, encoding, callback) {
     debug('write', arguments);
-    if (buffer && !aborted) {
-      if (! Buffer.isBuffer(buffer)) {
-        buffer = new Buffer(buffer, encoding);
+    if (!aborted) {
+      if (buffer) {
+        if (!Buffer.isBuffer(buffer)) {
+          buffer = new Buffer(buffer, encoding);
+        }
+        requestBodyBuffers.push(buffer);
       }
-      requestBodyBuffers.push(buffer);
+      if (typeof callback === 'function') {
+        callback();
+      }
     }
-    if (aborted) {
+    else {
       emitError(new Error('Request aborted'));
     }
 
@@ -146,13 +151,17 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     return false;
   };
 
-  req.end = function(buffer, encoding) {
+  req.end = function(buffer, encoding, callback) {
     debug('req.end');
     if (!aborted && !ended) {
-      req.write(buffer, encoding);
-      end(cb);
-      req.emit('finish');
-      req.emit('end');
+      req.write(buffer, encoding, function () {
+        if (typeof callback === 'function') {
+          callback();
+        }
+        end(cb);
+        req.emit('finish');
+        req.emit('end');
+      });
     }
     if (aborted) {
       emitError(new Error('Request aborted'));

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -3297,6 +3297,65 @@ test('delay works with replyWithError', function (t) {
 
 });
 
+test("write callback called", function(t) {
+  var scope = nock('http://www.filterboddiezregexp.com')
+    .filteringRequestBody(/mia/, 'nostra')
+    .post('/', 'mamma nostra')
+    .reply(200, "Hello World!");
+
+  var callbackCalled = false;
+  var req = http.request({
+                           host: "www.filterboddiezregexp.com"
+                           , method: 'POST'
+                           , path: '/'
+                           , port: 80
+                         }, function(res) {
+    t.equal(callbackCalled, true);
+    t.equal(res.statusCode, 200);
+    res.on('end', function() {
+      scope.done();
+      t.end();
+    });
+    // Streams start in 'paused' mode and must be started.
+    // See https://nodejs.org/api/stream.html#stream_class_stream_readable
+    res.resume();
+  });
+
+  req.write('mamma mia', null, function() {
+    callbackCalled = true;
+    req.end();
+  });
+});
+
+test("end callback called", function(t) {
+  var scope = nock('http://www.filterboddiezregexp.com')
+    .filteringRequestBody(/mia/, 'nostra')
+    .post('/', 'mamma nostra')
+    .reply(200, "Hello World!");
+
+  var callbackCalled = false;
+  var req = http.request({
+                           host: "www.filterboddiezregexp.com"
+                           , method: 'POST'
+                           , path: '/'
+                           , port: 80
+                         }, function(res) {
+    t.equal(callbackCalled, true);
+    t.equal(res.statusCode, 200);
+    res.on('end', function() {
+      scope.done();
+      t.end();
+    });
+    // Streams start in 'paused' mode and must be started.
+    // See https://nodejs.org/api/stream.html#stream_class_stream_readable
+    res.resume();
+  });
+
+  req.end('mamma mia', null, function() {
+    callbackCalled = true;
+  });
+});
+
 test("finish event fired before end event (bug-139)", function(t) {
   var scope = nock('http://www.filterboddiezregexp.com')
     .filteringRequestBody(/mia/, 'nostra')


### PR DESCRIPTION
The Node.js write and end methods take a callback as third argument; this pull request also adds them to the Nock interface.

Fixes #1046 and #1044.