### PR TITLE
Add extra warning about recording disabling mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1096,7 +1096,7 @@ Recording relies on intercepting real requests and answers and then persisting t
 
 In order to stop recording you should call `nock.restore()` and recording will stop.
 
-**ATTENTION!:** when recording is enabled, nock does no validation.
+**ATTENTION!:** when recording is enabled, nock does no validation, nor will any mocks be enabled.  Please be sure to turn off recording before attempting to use any mocks in your tests.
 
 ## `dont_print` option
 


### PR DESCRIPTION
Took me a while to figure out why my mocks weren't working.  It was because I had recording enabled, but I wasn't clear that it also disabled mocking.  Hopefully this will help avoid the problem for others.