### PR TITLE
example.com/unmocked no longer returns default page

### DIFF
--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -70,7 +70,7 @@ test("allow unmocked works after one interceptor is removed", function(t) {
     t.error(err);
     t.equal(body, 'Mocked');
 
-    mikealRequest("https://example.org/unmocked", function(err, resp, body) {
+    mikealRequest("https://example.org/?unmocked", function(err, resp, body) {
       t.error(err);
       t.assert(~body.indexOf('Example Domain'));
       t.end();


### PR DESCRIPTION
changing it to example.com/?unmocked fixes the problem. But I really don’t think it’s a good idea we rely on outside websites for our tests in the first place 🤔 