### PR TITLE
Record & replay binary file response correctly

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -52,17 +52,19 @@ var getBodyFromChunks = function(chunks, headers) {
   //  the body shouldn't be merged but instead persisted as an array
   //  of hex strings so that the responses can be mocked one by one.
   if(common.isContentEncoded(headers)) {
-    return _.map(chunks, function(chunk) {
-      if(!Buffer.isBuffer(chunk)) {
-        if (typeof chunk === 'string') {
-          chunk = new Buffer(chunk);
-        } else {
-          throw new Error('content-encoded responses must all be binary buffers');
+    return {
+      body: _.map(chunks, function(chunk) {
+        if(!Buffer.isBuffer(chunk)) {
+          if (typeof chunk === 'string') {
+            chunk = new Buffer(chunk);
+          } else {
+            throw new Error('content-encoded responses must all be binary buffers');
+          }
         }
-      }
 
-      return chunk.toString('hex');
-    });
+        return chunk.toString('hex');
+      })
+    };
   }
 
   var mergedBuffer = common.mergeChunks(chunks);
@@ -72,39 +74,55 @@ var getBodyFromChunks = function(chunks, headers) {
   //    2.  A string buffer which represents a JSON object.
   //    3.  A string buffer which doesn't represent a JSON object.
 
-  if(common.isBinaryBuffer(mergedBuffer)) {
-    return mergedBuffer.toString('hex');
+  var isBinary = common.isBinaryBuffer(mergedBuffer)
+  if(isBinary) {
+    return {
+      body: mergedBuffer.toString('hex'),
+      isBinary
+    }
   } else {
     var maybeStringifiedJson = mergedBuffer.toString('utf8');
     try {
-      return JSON.parse(maybeStringifiedJson);
+      return {
+        body: JSON.parse(maybeStringifiedJson),
+        isBinary: false
+      };
     } catch(err) {
-      return maybeStringifiedJson;
+      return {
+        body: maybeStringifiedJson,
+        isBinary: false
+      };
     }
   }
-
 };
 
 function generateRequestAndResponseObject(req, bodyChunks, options, res, dataChunks) {
 
+  var response = getBodyFromChunks(dataChunks, res.headers)
   options.path = req.path;
-  return {
+
+  var nockDef = {
     scope:    getScope(options),
     method:   getMethod(options),
     path:     options.path,
-    body:     getBodyFromChunks(bodyChunks),
+    body:     getBodyFromChunks(bodyChunks).body,
     status:   res.statusCode,
-    response: getBodyFromChunks(dataChunks, res.headers),
+    response: response.body,
     rawHeaders: res.rawHeaders || res.headers,
     reqheaders: req._headers
   };
 
+  if (response.isBinary) {
+    nockDef.responseIsBinary = true
+  }
+
+  return nockDef;
 }
 
 function generateRequestAndResponse(req, bodyChunks, options, res, dataChunks) {
 
-  var requestBody = getBodyFromChunks(bodyChunks);
-  var responseBody = getBodyFromChunks(dataChunks, res.headers);
+  var requestBody = getBodyFromChunks(bodyChunks).body;
+  var responseBody = getBodyFromChunks(dataChunks, res.headers).body;
 
   // Remove any query params from options.path so they can be added in the query() function
   var path = options.path;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -314,6 +314,8 @@ function define(nockDefs) {
     var response;
     if (!nockDef.response) {
       response = '';
+    } else if (nockDef.responseIsBinary) {
+      response = Buffer.from(nockDef.response, 'hex')
     } else {
       response = _.isString(nockDef.response) ? tryJsonParse(nockDef.response) : nockDef.response;
     }


### PR DESCRIPTION
The way nock currently implements the loading of previously recorded fixtures does not support proper binary responses, as nock cannot differentiate between a binary file encoded as hex string and a simple string. To work around that I've added a new flag to fixtures (`nockDef`): `responseIsBinary`.

I could not find a better workaround for it, but this works.

closes #1021, closes #1001, closes #524