### PR TITLE
fix: Allow allowUnmocked = true and regexp paths to work (#1034)

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -334,7 +334,7 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
 };
 
 Interceptor.prototype.matchIndependentOfBody = function matchIndependentOfBody(options) {
-    var isRegex = _.isRegExp(this.__nock_scopeKey) && _.isRegExp(this.path);
+    var isRegex = _.isRegExp(this.path);
 
     var method = (options.method || 'GET').toUpperCase()
         , path = options.path

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4548,6 +4548,19 @@ test('match path using regexp', function (t) {
   });
 });
 
+test('match path using regexp with allowUnmocked', function (t) {
+  nock('http://www.pathregex.com', {allowUnmocked: true})
+    .get(/regex$/)
+    .reply(200, 'Match regex');
+
+  mikealRequest.get('http://www.pathregex.com/resources/regex', function(err, res, body) {
+    t.type(err, 'null');
+    t.equal(res.statusCode, 200);
+    t.equal(body, 'Match regex');
+    t.end();
+  });
+});
+
 test('remove interceptor for GET resource', function(t) {
   var scope = nock('http://example.org')
     .get('/somepath')


### PR DESCRIPTION
I do not understand the implication of changing the condition with this commit, but this "fixes" the problem. My hope is that this is either enough to fix the issue or allow someone with a better understanding of what _.isRegExp(this.__nock_scopeKey) is doing to fix this. There didn't seem to be any tests that cover the condition, so I'm not sure how it's supposed to work.

fixes #1034