### PR TITLE
Fix usage under PhantomJS 2

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -74,11 +74,11 @@ var getBodyFromChunks = function(chunks, headers) {
   //    2.  A string buffer which represents a JSON object.
   //    3.  A string buffer which doesn't represent a JSON object.
 
-  var isBinary = common.isBinaryBuffer(mergedBuffer)
+  var isBinary = common.isBinaryBuffer(mergedBuffer);
   if(isBinary) {
     return {
       body: mergedBuffer.toString('hex'),
-      isBinary
+      isBinary: true
     }
   } else {
     var maybeStringifiedJson = mergedBuffer.toString('utf8');


### PR DESCRIPTION
Our PhantomJS build currently fails because of `nock` with the following error message:

```
PhantomJS 2.1.1 (Linux 0.0.0) ERROR
  SyntaxError: Unexpected token '}'
  at /tmp/node_modules/nock/lib/recorder.js:82:0
```

This change fixes the build.