### PR TITLE
CI: install npm@3 for Node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
     - node_js: 6
       script: npm run unit
     - node_js: 4
+      before_script: npm install -g npm@3
       script: npm run unit
     - stage: release
       node_js: lts/*


### PR DESCRIPTION
We will drop official support with the next breaking version of nock, but this will avoid false positives by Greenkeeper in the meanwhile 