### PR TITLE
feat: support URL objects

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -10,6 +10,7 @@ var RequestOverrider = require('./request_overrider'),
     Interceptor      = require('./interceptor'),
     http             = require('http'),
     parse            = require('url').parse,
+    URL              = require('url').URL,
     _                = require('lodash'),
     debug            = require('debug')('nock.intercept'),
     timers           = require('timers'),
@@ -357,6 +358,8 @@ function activate() {
 
     if (typeof options === 'string') {
       options = parse(options);
+    } else if (URL && options instanceof URL) {
+      options = parse(options.toString());
     }
     options.proto = proto;
 

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2600,6 +2600,31 @@ test('accept string as request target', function(t) {
   });
 });
 
+if (url.URL) {
+  test('accept URL as request target', function(t) {
+    var dataCalled = false;
+    var scope = nock('http://www.example.com')
+      .get('/')
+      .reply(200, "Hello World!");
+
+    http.get(new url.URL('http://www.example.com'), function(res) {
+      t.equal(res.statusCode, 200);
+
+      res.on('data', function(data) {
+        dataCalled = true;
+        t.ok(data instanceof Buffer, "data should be buffer");
+        t.equal(data.toString(), "Hello World!", "response should match");
+      });
+
+      res.on('end', function() {
+        t.ok(dataCalled);
+        scope.done();
+        t.end();
+      });
+    });
+  });
+}
+
 test('request has path', function(t) {
   var scope = nock('http://haspath.com')
     .get('/the/path/to/infinity')


### PR DESCRIPTION
`url.URL` was added in Node 7 and functions like `http.get()`,
`http.request()` accept URL objects as well as strings as their first
argument. Add support for that to nock.