### PR TITLE
fix(Buffer): update buffer constructors to use from and alloc

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -50,7 +50,7 @@ var isBinaryBuffer = function(buffer) {
 
   //  Test if the buffer can be reconstructed verbatim from its utf8 encoding.
   var utfEncodedBuffer = buffer.toString('utf8');
-  var reconstructedBuffer = new Buffer(utfEncodedBuffer, 'utf8');
+  var reconstructedBuffer = Buffer.from(utfEncodedBuffer, 'utf8');
   var compareBuffers = function(lhs, rhs) {
     if(lhs.length !== rhs.length) {
       return false;
@@ -80,7 +80,7 @@ var isBinaryBuffer = function(buffer) {
 var mergeChunks = function(chunks) {
 
   if(_.isEmpty(chunks)) {
-    return new Buffer(0);
+    return Buffer.alloc(0);
   }
 
   //  We assume that all chunks are Buffer objects if the first is buffer object.

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -395,7 +395,7 @@ Interceptor.prototype.basicAuth = function basicAuth(options) {
     var username = options['user'];
     var password = options['pass'] || '';
     var name = 'authorization';
-    var value = 'Basic ' + new Buffer(username + ':' + password).toString('base64');
+    var value = 'Basic ' + Buffer.from(username + ':' + password).toString('base64');
     this.interceptorMatchHeaders.push({ name: name, value: value });
     return this;
 };

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -56,7 +56,7 @@ var getBodyFromChunks = function(chunks, headers) {
       body: _.map(chunks, function(chunk) {
         if(!Buffer.isBuffer(chunk)) {
           if (typeof chunk === 'string') {
-            chunk = new Buffer(chunk);
+            chunk = Buffer.from(chunk);
           } else {
             throw new Error('content-encoded responses must all be binary buffers');
           }
@@ -330,7 +330,7 @@ function record(rec_options) {
       res.push = function(data) {
         if (data) {
           if (encoding) {
-            data = new Buffer(data, encoding);
+            data = Buffer.from(data, encoding);
           }
           dataChunks.push(data);
         }
@@ -358,7 +358,7 @@ function record(rec_options) {
         if (data) {
           debug(thisRecordingId, 'new', proto, 'body chunk');
           if (! Buffer.isBuffer(data)) {
-            data = new Buffer(data, encoding);
+            data = Buffer.from(data, encoding);
           }
           bodyChunks.push(data);
         }
@@ -373,7 +373,7 @@ function record(rec_options) {
         if (data) {
           debug(thisRecordingId, 'new', proto, 'body chunk');
           if (! Buffer.isBuffer(data)) {
-            data = new Buffer(data, encoding);
+            data = Buffer.from(data, encoding);
           }
           bodyChunks.push(data);
         }

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -112,7 +112,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
 
   /// options.auth
   if (options.auth && (! options.headers || ! options.headers.authorization)) {
-    setHeader(req, 'Authorization', 'Basic ' + (new Buffer(options.auth)).toString('base64'));
+    setHeader(req, 'Authorization', 'Basic ' + (Buffer.from(options.auth)).toString('base64'));
   }
 
   if (! req.connection) {
@@ -133,7 +133,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     if (!aborted) {
       if (buffer) {
         if (!Buffer.isBuffer(buffer)) {
-          buffer = new Buffer(buffer, encoding);
+          buffer = Buffer.from(buffer, encoding);
         }
         requestBodyBuffers.push(buffer);
       }
@@ -320,13 +320,13 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
             emitError(new Error('Gzip encoding is currently not supported in this version of Node.'));
             return;
           }
-          requestBody = String(zlib.gunzipSync(new Buffer(requestBody, 'hex')), 'hex')
+          requestBody = String(zlib.gunzipSync(Buffer.from(requestBody, 'hex')), 'hex')
         } else if (requestBody && common.contentEncoding(options.headers, 'deflate')) {
           if (typeof zlib.deflateSync !== 'function') {
             emitError(new Error('Deflate encoding is currently not supported in this version of Node.'));
             return;
           }
-          requestBody = String(zlib.inflateSync(new Buffer(requestBody, 'hex')), 'hex')
+          requestBody = String(zlib.inflateSync(Buffer.from(requestBody, 'hex')), 'hex')
         }
 
         requestBody = JSON.parse(requestBody);
@@ -358,7 +358,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
         }
 
         responseBuffers = _.map(buffers, function(buffer) {
-          return new Buffer(buffer, 'hex');
+          return Buffer.from(buffer, 'hex');
         });
 
       } else {
@@ -370,7 +370,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
         if(isBinaryRequestBodyBuffer && typeof(responseBody) === 'string') {
           //  Try to create the buffer from the interceptor's body response as hex.
           try {
-            responseBody = new Buffer(responseBody, 'hex');
+            responseBody = Buffer.from(responseBody, 'hex');
           } catch(err) {
             debug('exception during Buffer construction from hex data:', responseBody, '-', err);
           }
@@ -378,7 +378,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
           // Creating buffers does not necessarily throw errors, check for difference in size
           if (!responseBody || (interceptor.body.length > 0 && responseBody.length === 0)) {
             //  We fallback on constructing buffer from utf8 representation of the body.
-            responseBody = new Buffer(interceptor.body, 'utf8');
+            responseBody = Buffer.from(interceptor.body, 'utf8');
           }
         }
       }
@@ -444,7 +444,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
           });
         } else if (responseBody && !Buffer.isBuffer(responseBody)) {
           if (typeof responseBody === 'string') {
-            responseBody = new Buffer(responseBody);
+            responseBody = Buffer.from(responseBody);
           } else {
             responseBody = JSON.stringify(responseBody);
             response.headers['content-type'] = 'application/json';

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -57,7 +57,7 @@ Socket.prototype.applyDelay = function applyDelay(delayMs) {
 };
 
 Socket.prototype.getPeerCertificate = function getPeerCertificate() {
-  return new Buffer((Math.random() * 10000 + Date.now()).toString()).toString('base64');
+  return Buffer.from((Math.random() * 10000 + Date.now()).toString()).toString('base64');
 };
 
 Socket.prototype.destroy = function destroy() {

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -74,10 +74,10 @@ tap.test('isBinaryBuffer works', function(t) {
   t.false(common.isBinaryBuffer(''));
 
   //  Returns true for binary buffers.
-  t.true(common.isBinaryBuffer(new Buffer('8001', 'hex')));
+  t.true(common.isBinaryBuffer(Buffer.from('8001', 'hex')));
 
   //  Returns false for buffers containing strings.
-  t.false(common.isBinaryBuffer(new Buffer('8001', 'utf8')));
+  t.false(common.isBinaryBuffer(Buffer.from('8001', 'utf8')));
 
   t.end();
 

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1631,7 +1631,7 @@ test("response pipe", function(t) {
     function Constructor() {
       events.EventEmitter.call(this);
 
-      this.buffer = new Buffer(0);
+      this.buffer = Buffer.alloc(0);
       this.writable = true;
     }
 
@@ -1642,7 +1642,7 @@ test("response pipe", function(t) {
     };
 
     Constructor.prototype.write = function(chunk) {
-      var buf = new Buffer(this.buffer.length + chunk.length);
+      var buf = Buffer.alloc(this.buffer.length + chunk.length);
 
       this.buffer.copy(buf);
       chunk.copy(buf, this.buffer.length);
@@ -1682,7 +1682,7 @@ test("response pipe without implicit end", function(t) {
     function Constructor() {
       events.EventEmitter.call(this);
 
-      this.buffer = new Buffer(0);
+      this.buffer = Buffer.alloc(0);
       this.writable = true;
     }
 
@@ -1693,7 +1693,7 @@ test("response pipe without implicit end", function(t) {
     };
 
     Constructor.prototype.write = function(chunk) {
-      var buf = new Buffer(this.buffer.length + chunk.length);
+      var buf = Buffer.alloc(this.buffer.length + chunk.length);
 
       this.buffer.copy(buf);
       chunk.copy(buf, this.buffer.length);
@@ -3750,7 +3750,7 @@ test('define() works with binary buffers', function(t) {
     t.end();
   });
 
-  req.write(new Buffer(nockDef.body, 'hex'));
+  req.write(Buffer.from(nockDef.body, 'hex'));
   req.end();
 
 });
@@ -3873,7 +3873,7 @@ test('sending binary and receiving JSON should work ', function(t) {
   mikealRequest({
     method: 'POST',
     uri: 'http://example.com/some/path',
-    body: new Buffer('ffd8ffe000104a46494600010101006000600000ff', 'hex'),
+    body: Buffer.from('ffd8ffe000104a46494600010101006000600000ff', 'hex'),
     headers: { 'Accept': 'application/json', 'Content-Length': 23861 }
   }, function(err, res, body) {
       scope.done();
@@ -3896,7 +3896,7 @@ test('sending binary and receiving JSON should work ', function(t) {
 
 test('fix #146 - resume() is automatically invoked when the response is drained', function(t) {
   var replyLength = 1024 * 1024;
-  var replyBuffer = new Buffer((new Array(replyLength + 1)).join("."));
+  var replyBuffer = Buffer.from((new Array(replyLength + 1)).join("."));
   t.equal(replyBuffer.length, replyLength);
 
   nock("http://www.abc.com")
@@ -4434,7 +4434,7 @@ test("match basic authentication header", function(t) {
   var username = 'testuser'
     , password = 'testpassword'
     , authString = username + ":" + password
-    , encrypted = (new Buffer(authString)).toString( 'base64' );
+    , encrypted = (Buffer.from(authString)).toString( 'base64' );
 
   var scope = nock('http://www.headdy.com')
      .get('/')

--- a/tests/test_isomorphic_fetch.js
+++ b/tests/test_isomorphic_fetch.js
@@ -61,7 +61,7 @@ test("basicAuth match works", function (t) {
 
   return fetch('http://isomorphicfetchland.com/path2', {
     headers: {
-      'Authorization': 'Basic ' + new Buffer('username:password').toString('base64'),
+      'Authorization': 'Basic ' + Buffer.from('username:password').toString('base64'),
     }
   }).
     then(function (res) {
@@ -78,7 +78,7 @@ test("basicAuth match works", function (t) {
 });
 
 test("matchHeader works", function (t) {
-  var authorizationHeader = 'Basic ' + new Buffer('username:password').toString('base64');
+  var authorizationHeader = 'Basic ' + Buffer.from('username:password').toString('base64');
 
   var scope = nock('http://isomorphicfetchland.com').
     get('/path2').

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -898,7 +898,7 @@ test("respects http.request() consumers", function(t) {
                   , path:'/' }
     ;
     var req = http.request(options, function (res) {
-      var buffer = new Buffer('');
+      var buffer = Buffer.from('');
 
       setTimeout(function () {
         res

--- a/tests/test_s3.js
+++ b/tests/test_s3.js
@@ -25,7 +25,7 @@ test('works with s3, body < 1024 ^ 2', function (t) {
 
   bucket.putObject({
       Key: 'key',
-      Body: new Buffer(1024 * 1024 - 1), // works
+      Body: Buffer.alloc(1024 * 1024 - 1), // works
       // Body: new Buffer(1024 * 1024), // doesn't work
       ContentType: 'binary/octet-stream'
     },
@@ -57,7 +57,7 @@ test('works with s3, body = 10 * 1024 ^ 2', function (t) {
 
   bucket.putObject({
       Key: 'key',
-      Body: new Buffer(10 * 1024 * 1024), // doesn't work
+      Body: Buffer.alloc(10 * 1024 * 1024), // doesn't work
       ContentType: 'binary/octet-stream'
     },
     function (err, resp) {
@@ -88,7 +88,7 @@ test('works with s3, body = 16 * 1024 ^ 2', function (t) {
 
   bucket.putObject({
       Key: 'key',
-      Body: new Buffer(16 * 1024 * 1024), // doesn't work
+      Body: Buffer.alloc(16 * 1024 * 1024), // doesn't work
       ContentType: 'binary/octet-stream'
     },
     function (err, resp) {


### PR DESCRIPTION
No longer throws DeprecationWarning as described in #1140 
Not sure whats up but fails the same tests as `master` branch so I assume that is okay?

https://nodejs.org/docs/latest/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe