### PR TITLE
fix(issue-1137): No match when basePath is regex and path is function

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -306,7 +306,7 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
 
     if (typeof this.uri === 'function') {
         matches = matchQueries &&
-            method.toUpperCase() + ' ' + proto + '://' + options.host === this.baseUri &&
+            common.matchStringOrRegexp(matchKey, this.basePath) &&
             this.uri.call(this, path);
     } else {
         matches = method === this.method &&

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4569,7 +4569,22 @@ test('match domain using regexp', function (t) {
   });
 });
 
+test('match domain using regexp with path as callback (issue-1137)', function (t) {
+  nock.cleanAll();
+  nock(/.*/)
+    .get(() => true)
+    .reply(200, 'Match regex');
+
+  mikealRequest.get('http://www.regexexample.com/resources', function(err, res, body) {
+    t.type(err, 'null');
+    t.equal(res.statusCode, 200);
+    t.equal(body, 'Match regex');
+    t.end();
+  });
+});
+
 test('match multiple interceptors with regexp domain (issue-508)', function (t) {
+  nock.cleanAll();
   nock(/chainregex/)
     .get('/')
     .reply(200, 'Match regex')

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -279,7 +279,7 @@ test('records nonstandard ports', function(t) {
   //  Create test http server and perform the tests while it's up.
   var testServer = http.createServer(function(req, res) {
     res.end(RESPONSE_BODY);
-  }).listen(8081, function(err) {
+  }).listen(8082, function(err) {
 
     t.equal(err, undefined);
 
@@ -741,7 +741,7 @@ test('works with clients listening for readable', {skip: process.env.AIRPLANE}, 
   //  Create test http server and perform the tests while it's up.
   var testServer = http.createServer(function(req, res) {
     res.end(RESPONSE_BODY);
-  }).listen(8081, function(err) {
+  }).listen(8082, function(err) {
 
     // t.equal(err, undefined);
 
@@ -882,7 +882,7 @@ test("respects http.request() consumers", function(t) {
     setTimeout(function() {
       res.end('bar');
     }, 25);
-  }).listen(8082, function(err) {
+  }).listen(8083, function(err) {
     t.equal(err, undefined);
 
     nock.restore();


### PR DESCRIPTION
I had to update the port numbers in the `test_recorder.py` because the test cases were failing with the `EADDRINUSE` error for port 8081.