### PR TITLE
chore(package): update restify-clients to version 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "nyc": "^12.0.1",
     "request": "^2.83.0",
     "request-promise": "^4.2.2",
-    "restify-clients": "^2.0.0",
+    "restify-clients": "^2.2.0",
     "rimraf": "^2.6.2",
     "semantic-release": "^15.0.0",
     "superagent": "^3.8.2",


### PR DESCRIPTION
closes #1146, should help with https://github.com/node-nock/nock/pull/1145#issuecomment-395563855